### PR TITLE
Link boost symbols statically

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,6 +13,7 @@ cd build-dir
 cmake \
     -DCMAKE_BUILD_TYPE=release \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DARROW_BOOST_USE_SHARED=off \
     -DARROW_BUILD_BENCHMARKS=off \
     -DARROW_BUILD_TESTS=off \
     -DARROW_HDFS=on \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 01ff68b9ab2785cc2a465fedc62536faab4ff461b6d42b9b00df15bb2e41dfa5
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Otherwise downstream users must also install boost runtime libraries (like libboost_filesystem.so)