### PR TITLE
[Do not merge] Add ORC support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,7 @@ cmake \
     -DARROW_BUILD_TESTS=OFF \
     -DARROW_JEMALLOC=OFF \
     -DARROW_PLASMA=ON \
+    -DARROW_ORC=ON \
     -DARROW_PYTHON=ON \
     ..
 


### PR DESCRIPTION
Changes the non-windows build script to build optional ORC reader
support. This is unsupported currently on windows, so no need to change
the windows build script.