### PR TITLE
Relax pinning of vc package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - update-brotli-suffix.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win32]
   skip: true  # [win and py<35]
   features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - python
     - numpy >=1.10  # [not (win and py>=36)]
     - numpy >=1.12  # [win and py>=36]
-    - vc 14  # [win and py>=35]
+    - vc 14.*  # [win and py>=35]
     - snappy  # [win and py>=35]
 
 test:


### PR DESCRIPTION
Currently `arrow-cpp` can't be installed alongside `pytorch` on Windows because of the strict version pinning in this recipe.

`arrow-cpp` pins the `vc` package to *exactly* 14:
```
arrow-cpp 0.8.0 py36_vc14_3
---------------------------
dependencies:
    numpy >=1.12
    python 3.6*
    snappy
    vc 14
```
```
vc 14 h0510ff6_3
----------------
dependencies:
    vs2015_runtime >=14.0.25123,<15.0a0
```
...whereas `pytorch` relies on the newer (but compatible) version 14.1:
```
vc 14.1 h21ff451_0
------------------
dependencies:
    vs2017_runtime >=15.4.27004.2010,<16.0a0
```

IIUC this change should allow both packages to happily coexist in the same environment!

***Refs:***
 * https://gitter.im/conda/conda?at=5a90356e35dd17022ee48639
 * https://github.com/conda-forge/conda-forge.github.io/issues/537#issuecomment-368240291
