### PR TITLE
Add run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,13 @@ source:
     - 0001-ARROW-3711-C-Don-t-pass-CXX_FLAGS-to-C_FLAGS.patch
 
 build:
-  number: 1002
+  number: 1003
   skip: true  # [win32]
   skip: true  # [win and py<35]
   features:
     - vc14  # [win and py>=35]
+  run_exports:
+    - {{ pin_subpackage("arrow-cpp", max_pin="x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
Fixes #58 

@mariusvniekerk Is this enough for the pinning? I don't see any changes in `AnacondaRecipes/arrow-cpp` that would be worthwhile here. It would probably better be if @msarahan could tell us what we need to improve upstream so Anaconda could get rid of them in their recipes.