### PR TITLE
Ignore `run_exports` of `cudatoolkit` in `pyarrow`

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -100,13 +100,13 @@ jobs:
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
         call activate base
-        validate_recipe_outputs "arrow-cpp-feedstock"
+        validate_recipe_outputs "arrow-cpp"
       displayName: Validate Recipe Outputs
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         call activate base
-        upload_package --validate --feedstock-name="arrow-cpp-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package --validate --feedstock-name="arrow-cpp" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/migrations/re220200601.yaml
+++ b/.ci_support/migrations/re220200601.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1591012622.9213123
-re2:
-- 2020.06.01

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cpcloud @jreback @kou @kszucs @leifwalsh @nealrichardson @pcmoritz @pearu @pitrou @robertnishihara @siddharthteotia @wesm @xhochy
+* @cpcloud @jakirkham @jreback @kou @kszucs @leifwalsh @nealrichardson @pcmoritz @pearu @pitrou @robertnishihara @siddharthteotia @wesm @xhochy

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,10 +31,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "arrow-cpp-feedstock"
+validate_recipe_outputs "arrow-cpp"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="arrow-cpp-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package --validate --feedstock-name="arrow-cpp" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -48,9 +48,9 @@ set -e
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-validate_recipe_outputs "arrow-cpp-feedstock"
+validate_recipe_outputs "arrow-cpp"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package --validate --feedstock-name="arrow-cpp-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="arrow-cpp" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Feedstock Maintainers
 =====================
 
 * [@cpcloud](https://github.com/cpcloud/)
+* [@jakirkham](https://github.com/jakirkham/)
 * [@jreback](https://github.com/jreback/)
 * [@kou](https://github.com/kou/)
 * [@kszucs](https://github.com/kszucs/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -247,3 +247,4 @@ extra:
     - pitrou
     - pearu
     - nealrichardson
+    - jakirkham

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.17.1" %}
-{% set number = "3" %}
+{% set number = "4" %}
 {% set cuda_enabled = cuda_compiler_version is not undefined and cuda_compiler_version == '9.2' %}
 {% set build_ext_version = "1.0.0" %}
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -165,6 +165,8 @@ outputs:
       number: {{ number }}
       string: "{{ build_string }}"
       skip: true  # [cuda_compiler_version not in (undefined, "None", "9.2")]
+      ignore_run_exports:
+        - cudatoolkit
       track_features:
         {{ "- arrow-cuda" if cuda_enabled else "" }}
     requirements:


### PR DESCRIPTION
Just as we are ignoring `run_exports` in `arrow-cpp`, we need to do the same in `pyarrow`. This is needed to ensure we do not pin `cudatoolkit` to `9.2`, but merely ensure `cudatoolkit` is at least `9.2`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/arrow-cpp-feedstock/issues/149

<!--
Please add any other relevant info below:
-->
