### PR TITLE
Add ppc64le to build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -72,38 +72,6 @@ jobs:
         CONFIG: linux_64_boost_cpp1.74.0cuda_compiler_versionNonenumpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython:
-        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -72,6 +72,38 @@ jobs:
         CONFIG: linux_64_boost_cpp1.74.0cuda_compiler_versionNonenumpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython:
+        CONFIG: linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.72.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.72.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.72.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.72.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.19'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.74.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.74.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.74.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython.yaml
@@ -1,0 +1,67 @@
+aws_sdk_cpp:
+- 1.8.70
+boost_cpp:
+- 1.74.0
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+gflags:
+- '2.2'
+glog:
+- 0.4.0
+grpc_cpp:
+- '1.33'
+libprotobuf:
+- '3.13'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.19'
+orc:
+- 1.6.5
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+re2:
+- 2020.10.01
+snappy:
+- '1'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
+zlib:
+- '1.2'
+zstd:
+- '1.4'

--- a/.ci_support/migrations/aws_sdk_cpp1870.yaml
+++ b/.ci_support/migrations/aws_sdk_cpp1870.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-aws_sdk_cpp:
-- 1.8.70
-migrator_ts: 1603197125.0618536

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Current build status
 
 
 <table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/arrow-cpp-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/arrow-cpp-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr><tr>
     <td>Drone</td>
     <td>
       <a href="https://cloud.drone.io/conda-forge/arrow-cpp-feedstock">

--- a/README.md
+++ b/README.md
@@ -202,6 +202,62 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.72.0numpy1.16python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.72.0numpy1.16python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.72.0numpy1.16python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.72.0numpy1.19python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.74.0numpy1.16python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.74.0numpy1.16python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.74.0numpy1.16python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_boost_cpp1.74.0numpy1.19python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_boost_cpp1.72.0numpy1.16python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=master">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,3 @@
 # linux_ppc64le is explicitly removed again, see https://github.com/conda-forge/arrow-cpp-feedstock/issues/143
-provider: {linux_aarch64: default, linux_ppc64le: azure, win: azure}
+provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 conda_forge_output_validation: true

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,3 @@
 # linux_ppc64le is explicitly removed again, see https://github.com/conda-forge/arrow-cpp-feedstock/issues/143
-provider: {linux_aarch64: default, win: azure}
+provider: {linux_aarch64: default, linux_ppc64le: azure, win: azure}
 conda_forge_output_validation: true

--- a/recipe/build-arrow.sh
+++ b/recipe/build-arrow.sh
@@ -75,7 +75,7 @@ cmake \
 
 # Decrease parallelism a bit as we will otherwise get out-of-memory problems
 # This is only necessary on Travis
-if [ "${TRAVIS}" = "true" ]; then
+if [ "${CI}" = "travis" ]; then
 # if [ "$(uname -m)" = "ppc64le" ]; then
     echo "Using $(grep -c ^processor /proc/cpuinfo) CPUs"
     CPU_COUNT=$(grep -c ^processor /proc/cpuinfo)

--- a/recipe/build-pyarrow.sh
+++ b/recipe/build-pyarrow.sh
@@ -36,6 +36,15 @@ fi
 
 cd python
 
+# Decrease parallelism to avoid out-of-memory problems
+# This is only necessary on Travis
+if [ "${CI}" = "travis" ]; then
+    echo "Using $(grep -c ^processor /proc/cpuinfo) CPUs"
+    CPU_COUNT=$(grep -c ^processor /proc/cpuinfo)
+    CPU_COUNT=$((CPU_COUNT / 4))
+    export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
+fi
+
 $PYTHON setup.py \
         build_ext \
         install --single-version-externally-managed \


### PR DESCRIPTION
Tentatively re-enable the ppc64le build, as suggested by @xhochy 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
