### PR TITLE
Remove aws-sdk-cpp runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,6 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ compiler("cuda") }}  # [cuda_compiler_version != "None"]
       host:
-        - aws-sdk-cpp
         - boost-cpp >=1.70
         - brotli
         - bzip2


### PR DESCRIPTION
`aws-sdk-cpp` is a runtime dependency, but it should not be required to use Apache Arrow and `pyarrow` specifically. I'm not sure whether I can simply remove it without any consequences. Maybe it should just be a build dependency.