### PR TITLE
Readd `1.0.x` migrations

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,5 +6,6 @@ conda_forge_output_validation: true
 test_on_native_only: true
 bot:
   abi_migration_branches:
+    - "1.0.x"
     - "2.0.x"
     - "3.0.x"


### PR DESCRIPTION
Currently in RAPIDS we are still on Arrow 1.0. Have run into segfaults when trying to upgrade to 4.0 ( https://github.com/rapidsai/cudf/pull/7495 ). Our most recent release is still on Arrow 1.0 for this reason. However there are some conflicts when installing (particularly around libthrift version 0.14.2). Try to resuscitate this branch to clear up those issues for users trying to install the last release.

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
