### PR TITLE
[main] Rebuild for grpc 1.49 

### DIFF
--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.20python3.8.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.20python3.9.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.21python3.10.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_versionNonecxx_compiler_version10numpy1.23python3.11.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20python3.8.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20python3.9.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.21python3.10.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.23python3.11.____cpython.yaml
@@ -29,7 +29,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.20python3.8.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.20python3.9.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.21python3.10.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version11.2numpy1.23python3.11.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.20python3.8.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.20python3.9.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.21python3.10.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonenumpy1.23python3.11.____cpython.yaml
@@ -33,7 +33,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_ppc64le_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20python3.8.____cpython.yaml
@@ -27,7 +27,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_ppc64le_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20python3.9.____cpython.yaml
@@ -27,7 +27,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
@@ -27,7 +27,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
@@ -27,7 +27,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/migrations/grpc_cpp149.yaml
+++ b/.ci_support/migrations/grpc_cpp149.yaml
@@ -1,0 +1,13 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+
+# TODO: once the migration finishes and all feedstocks
+# have changed to the new output, remove grpc_cpp
+libgrpc:
+- '1.49'
+grpc_cpp:
+- '1.49'
+
+migrator_ts: 1666974156.3232300

--- a/.ci_support/osx_64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.8.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/osx_64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.9.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/osx_arm64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20python3.8.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/osx_arm64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20python3.9.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -25,7 +25,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_version10.2numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2numpy1.20python3.8.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_version10.2numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2numpy1.20python3.9.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_version10.2numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2numpy1.21python3.10.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_version10.2numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2numpy1.23python3.11.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_versionNonenumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonenumpy1.20python3.8.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_versionNonenumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonenumpy1.20python3.9.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_versionNonenumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonenumpy1.21python3.10.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compiler_versionNonenumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonenumpy1.23python3.11.____cpython.yaml
@@ -21,7 +21,7 @@ glog:
 google_cloud_cpp:
 - '2.2'
 grpc_cpp:
-- '1.47'
+- '1.49'
 libabseil:
 - '20220623.0'
 libprotobuf:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0001-ARROW-17433-CI-C-Use-Visual-Studio-2019-on-AppVeyor-.patch
 
 build:
-  number: 8
+  number: 9
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [(win or linux64) and cuda_compiler_version not in ("None", "10.2")]


### PR DESCRIPTION
Bot thinks https://github.com/conda-forge/google-cloud-cpp-feedstock/pull/119 hasn't happened yet. Gives us a chance to do this more slowly (rather than have the bot hit the feedstock with ~4 big PRs in a queue already strained by py3.11)