### PR TITLE
[RFC] Keep building for py37 

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version10.2openssl1.1.1.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2openssl1.1.1.yaml
@@ -45,6 +45,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - 1.1.1
 orc:
@@ -56,6 +57,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/linux_64_cuda_compiler_version10.2openssl3.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2openssl3.yaml
@@ -45,6 +45,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - '3'
 orc:
@@ -56,6 +57,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/linux_64_cuda_compiler_versionNoneopenssl1.1.1.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNoneopenssl1.1.1.yaml
@@ -45,6 +45,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - 1.1.1
 orc:
@@ -56,6 +57,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/linux_64_cuda_compiler_versionNoneopenssl3.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNoneopenssl3.yaml
@@ -45,6 +45,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - '3'
 orc:
@@ -56,6 +57,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNoneopenssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNoneopenssl1.1.1.yaml
@@ -45,6 +45,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - 1.1.1
 orc:
@@ -56,6 +57,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNoneopenssl3.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNoneopenssl3.yaml
@@ -45,6 +45,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - '3'
 orc:
@@ -56,6 +57,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/linux_ppc64le_cuda_compiler_versionNoneopenssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_versionNoneopenssl1.1.1.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - 1.1.1
 orc:
@@ -52,6 +53,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/linux_ppc64le_cuda_compiler_versionNoneopenssl3.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_versionNoneopenssl3.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - '3'
 orc:
@@ -52,6 +53,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - 1.1.1
 orc:
@@ -52,6 +53,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - '3'
 orc:
@@ -52,6 +53,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/win_64_cuda_compiler_version10.2openssl1.1.1.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2openssl1.1.1.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - 1.1.1
 pin_run_as_build:
@@ -50,6 +51,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/win_64_cuda_compiler_version10.2openssl3.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2openssl3.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - '3'
 pin_run_as_build:
@@ -50,6 +51,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/win_64_cuda_compiler_versionNoneopenssl1.1.1.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNoneopenssl1.1.1.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - 1.1.1
 pin_run_as_build:
@@ -50,6 +51,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/.ci_support/win_64_cuda_compiler_versionNoneopenssl3.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNoneopenssl3.yaml
@@ -41,6 +41,7 @@ numpy:
 - '1.23'
 - '1.20'
 - '1.20'
+- '1.20'
 openssl:
 - '3'
 pin_run_as_build:
@@ -50,6 +51,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 re2:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,17 @@
+# exceptionally reinstate python 3.7 support, to be removed
+# at any time, but ideally once upstream drops support itself
+python:
+  - 3.7.* *_cpython   # [not (osx and arm64)]
+  - 3.8.* *_cpython
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+python_impl:
+  - cpython           # [not (osx and arm64)]
+  - cpython
+  - cpython
+  - cpython
+numpy:
+  - 1.20              # [not (osx and arm64)]
+  - 1.20
+  - 1.20
+  - 1.21

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,8 +5,10 @@ python:
   - 3.8.* *_cpython
   - 3.9.* *_cpython
   - 3.10.* *_cpython
+  - 3.11.* *_cpython
 python_impl:
   - cpython           # [not (osx and arm64)]
+  - cpython
   - cpython
   - cpython
   - cpython
@@ -15,3 +17,4 @@ numpy:
   - 1.20
   - 1.20
   - 1.21
+  - 1.23


### PR DESCRIPTION
This was explicitly [requested](https://github.com/conda-forge/arrow-cpp-feedstock/pull/875#issuecomment-1332753403) by @rxm7706, and also [asked about](https://github.com/conda-forge/arrow-cpp-feedstock/pull/875#pullrequestreview-1199167120) by upstream dev @raulcd in the same PR.

I said at the time:
> It's technically possible. Assuming the CI passes it would not add an extreme maintenance burden, though it depends also whether the other maintainers agree (w.r.t. precedent etc.). But this will be a topic for a separate PR.

This PR is to see if it passes CI cleanly (thankfully, the host deps don't carry much python-deps that are migration-sensitive, so this might just work), and then gather feedback from @conda-forge/arrow-cpp if we actually want to do this.