### PR TITLE
[8.0.x] Fix ORC 1.8.1 migration

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - 1.1.1
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - 1.1.1
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.8.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.9.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - 1.1.1
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.21openssl3python3.10.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - 1.1.1
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.23openssl3python3.11.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20openssl3python3.8.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.20openssl3python3.9.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.21openssl3python3.10.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7numpy1.23openssl3python3.11.____cpython.yaml
@@ -45,7 +45,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.20openssl3python3.8.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.20openssl3python3.9.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.21openssl3python3.10.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10numpy1.23openssl3python3.11.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.8.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.20openssl3python3.9.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.21openssl3python3.10.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11numpy1.23openssl3python3.11.____cpython.yaml
@@ -49,7 +49,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/migrations/orc181.yaml
+++ b/.ci_support/migrations/orc181.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1670688384.9056673
-orc:
-- 1.8.1

--- a/.ci_support/osx_64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -41,7 +41,7 @@ numpy:
 openssl:
 - '3'
 orc:
-- 1.8.0
+- 1.8.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,7 +121,7 @@ outputs:
         - python
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
-        - cudatoolkit >={{ cuda_compiler_version_min }}  # [cuda_compiler_version != "None"]
+        - cudatoolkit >=9.2  # [cuda_compiler_version != "None"]
 
     about:
       home: http://github.com/apache/arrow
@@ -207,7 +207,7 @@ outputs:
         - python
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
-        - cudatoolkit >={{ cuda_compiler_version_min }}  # [cuda_compiler_version != "None"]
+        - cudatoolkit >=9.2  # [cuda_compiler_version != "None"]
 
     about:
       home: http://github.com/apache/arrow
@@ -281,7 +281,7 @@ outputs:
         - python
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
-        - cudatoolkit >={{ cuda_compiler_version_min }}  # [cuda_compiler_version != "None"]
+        - cudatoolkit >=9.2  # [cuda_compiler_version != "None"]
 
     about:
       home: http://github.com/apache/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - patches/0002-ARROW-16730-C-Bump-vendored-jemalloc-version-13294.patch
 
 build:
-  number: 12
+  number: 13
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]


### PR DESCRIPTION
Looks like in the whole migration merging rerendering process the changes got lost in most of the builds.

cc @h-vetinari @jakirkham

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.