### PR TITLE
Reinstate ucx support

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2.yaml
@@ -68,6 +68,8 @@ target_platform:
 - linux-64
 thrift_cpp:
 - 0.18.1
+ucx:
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -68,6 +68,8 @@ target_platform:
 - linux-64
 thrift_cpp:
 - 0.18.1
+ucx:
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
@@ -68,6 +68,8 @@ target_platform:
 - linux-aarch64
 thrift_cpp:
 - 0.18.1
+ucx:
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
@@ -64,6 +64,8 @@ target_platform:
 - linux-ppc64le
 thrift_cpp:
 - 0.18.1
+ucx:
+- 1.14.0
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/migrations/orc183.yaml
+++ b/.ci_support/migrations/orc183.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1678966654.4601161
-orc:
-- 1.8.3

--- a/.ci_support/migrations/ucx1410.yaml
+++ b/.ci_support/migrations/ucx1410.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  use_local: true
+ucx:
+- '1.14.0'
+migrator_ts: 1679152574.207815

--- a/recipe/build-arrow.sh
+++ b/recipe/build-arrow.sh
@@ -18,10 +18,13 @@ EXTRA_CMAKE_ARGS=""
 if [ "$(uname)" == "Linux" ]; then
   SYSTEM_INCLUDES=$(echo | ${CXX} -E -Wp,-v -xc++ - 2>&1 | grep '^ ' | awk '{print "-isystem;" substr($1, 1)}' | tr '\n' ';')
   ARROW_GANDIVA_PC_CXX_FLAGS="${SYSTEM_INCLUDES}"
+  # only available on linux
+  ARROW_WITH_UCX=ON
 else
   # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
   CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
   ARROW_GANDIVA_PC_CXX_FLAGS="-D_LIBCPP_DISABLE_AVAILABILITY"
+  ARROW_WITH_UCX=OFF
 fi
 
 # Enable CUDA support
@@ -108,6 +111,7 @@ cmake -GNinja \
     -DARROW_WITH_NLOHMANN_JSON=ON \
     -DARROW_WITH_OPENTELEMETRY=${READ_RECIPE_META_YAML_WHY_NOT} \
     -DARROW_WITH_SNAPPY=ON \
+    -DARROW_WITH_UCX=${ARROW_WITH_UCX} \
     -DARROW_WITH_ZLIB=ON \
     -DARROW_WITH_ZSTD=ON \
     -DBUILD_SHARED_LIBS=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
     folder: testing
 
 build:
-  number: 12
+  number: 13
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]
@@ -136,8 +136,7 @@ outputs:
         - re2
         - snappy
         - thrift-cpp
-        # https://github.com/conda-forge/arrow-cpp-feedstock/issues/962
-        # - ucx          # [linux]
+        - ucx          # [linux]
         - xsimd
         - zlib
         - zstd


### PR DESCRIPTION
Undo https://github.com/conda-forge/arrow-cpp-feedstock/pull/963 now that https://github.com/conda-forge/ucx-split-feedstock/pull/111 has been merged. Includes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4256