### PR TITLE
[NO MRG] Testing "Add `cuda_compiler` to `zip_keys`"

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2.yaml
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -17,7 +17,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_cuda_compiler_version11.2.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version11.2.yaml
@@ -79,6 +79,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -79,6 +79,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compiler_version11.2.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_version11.2.yaml
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
@@ -17,7 +17,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -28,14 +28,16 @@ cxx_compiler_version:          # [ppc64le or aarch64]
 fortran_compiler_version:      # [ppc64le or aarch64]
   - 10                         # [ppc64le or aarch64]
 
+cuda_compiler:                 # [ppc64le or aarch64]
+  - nvcc                       # [ppc64le or aarch64]
 cuda_compiler_version:         # [ppc64le or aarch64]
   - 11.2                       # [ppc64le or aarch64]
 
-cudnn:                         # [ppc64le or aarch64]
-  - 8                          # [ppc64le or aarch64]
+cudnn:                  # [ppc64le or aarch64]
+  - 8                   # [ppc64le or aarch64]
 
-cdt_name:                      # [ppc64le or aarch64]
-  - cos7                       # [ppc64le or aarch64]
+cdt_name:  # [ppc64le or aarch64]
+  - cos7   # [ppc64le or aarch64]
 
 docker_image:                                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux") and (ppc64le or aarch64)]
    # case: native compilation (build == target)

--- a/.ci_support/win_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2.yaml
@@ -65,6 +65,8 @@ target_platform:
 thrift_cpp:
 - 0.18.1
 zip_keys:
+- - cuda_compiler
+  - cuda_compiler_version
 - - python
   - numpy
 zlib:

--- a/.ci_support/win_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNone.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -65,6 +65,8 @@ target_platform:
 thrift_cpp:
 - 0.18.1
 zip_keys:
+- - cuda_compiler
+  - cuda_compiler_version
 - - python
   - numpy
 zlib:


### PR DESCRIPTION
Testing out the changes in PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4407 ) to add `cuda_compiler` to `zip_keys`. Also copies over the CUDA arch migrator changes and uses the local copy of that to test those work ok too.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
