### PR TITLE
[11.0.x] Rebuild for libgoogle_cloud2100 

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2.yaml
@@ -33,7 +33,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -17,7 +17,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -33,7 +33,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_cuda_compiler_version11.2.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version11.2.yaml
@@ -37,7 +37,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:
@@ -79,6 +79,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -37,7 +37,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:
@@ -79,6 +79,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compiler_version11.2.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_version11.2.yaml
@@ -33,7 +33,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
@@ -17,7 +17,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -33,7 +33,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:
@@ -75,6 +75,7 @@ ucx:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/migrations/aws_sdk_cpp19375.yaml
+++ b/.ci_support/migrations/aws_sdk_cpp19375.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  use_local: true
-aws_sdk_cpp:
-- 1.9.379
-migrator_ts: 1667321224.1701944

--- a/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -15,7 +15,6 @@ __migrator:
   wait_for_migrators:
     - aarch64 and ppc64le addition
   exclude_pinned_pkgs: False
-  use_local: true
   commit_message: "Rebuild for cuda for ppc64le and aarch64"
 
 arm_variant_type:              # [aarch64]

--- a/.ci_support/migrations/libgoogle_cloud2100.yaml
+++ b/.ci_support/migrations/libgoogle_cloud2100.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libgoogle_cloud:
+- 2.10.0
+google_cloud_cpp:
+- 2.10.0
+migrator_ts: 1683064486.2253776

--- a/.ci_support/migrations/ucx1410.yaml
+++ b/.ci_support/migrations/ucx1410.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  use_local: true
-ucx:
-- '1.14.0'
-migrator_ts: 1679152574.207815

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -27,7 +27,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -27,7 +27,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libevent:

--- a/.ci_support/win_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/win_64_cuda_compiler_version10.2.yaml
@@ -23,7 +23,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libcrc32c:
@@ -65,6 +65,8 @@ target_platform:
 thrift_cpp:
 - 0.18.1
 zip_keys:
+- - cuda_compiler
+  - cuda_compiler_version
 - - python
   - numpy
 zlib:

--- a/.ci_support/win_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNone.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -23,7 +23,7 @@ gflags:
 glog:
 - '0.6'
 google_cloud_cpp:
-- 2.9.1
+- 2.10.0
 libabseil:
 - '20230125'
 libcrc32c:
@@ -65,6 +65,8 @@ target_platform:
 thrift_cpp:
 - 0.18.1
 zip_keys:
+- - cuda_compiler
+  - cuda_compiler_version
 - - python
   - numpy
 zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ source:
     folder: testing
 
 build:
-  number: 18
+  number: 19
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]


### PR DESCRIPTION
Not sure why migrator failed to open for these two branches (perhaps related again to ucx or the outdated migrations with `use_local`)