### PR TITLE
Fix unbound variable in activate script

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -8,7 +8,7 @@
 # is benign and doesn't need to be deleted.
 
 _la_log() {
-    if [ "$CF_LIBARROW_ACTIVATE_LOGGING" = "1" ]; then
+    if [ "${CF_LIBARROW_ACTIVATE_LOGGING:-}" = "1" ]; then
         # The following loop is necessary to handle multi-line strings
         # like for the output of `ls -al`.
         printf '%s\n' "$*" | while IFS= read -r line

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     folder: testing
 
 build:
-  number: 4
+  number: 5
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]


### PR DESCRIPTION
We were checking `CF_LIBARROW_ACTIVATE_LOGGING` without a default value. This led to failure under `set -u`. For original report from @plattenschieber, see <https://github.com/conda-forge/arrow-cpp-feedstock/pull/1065#issuecomment-1571699535>:

> We stumbled upon an issue in our ci which seems to be related to this PR, as yesterdays build seems fine and todays doesn't work anymore :sweat_smile:
> 
> ```
> Transaction finished
> /workspace/repo/.env/etc/conda/activate.d/libarrow_activate.sh: line 11: CF_LIBARROW_ACTIVATE_LOGGING: unbound variable
> ```
> 
> The only change I could see was in the build number of `pyarrow` 12.0.0 `libarrow 12.0.0 h96638e8_3_cpu` worked fine -> `libarrow 12.0.0 h96638e8_4_cpu` got error from above



<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
