### PR TITLE
Stabilize CI by skipping crashy/flaky tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -367,6 +367,8 @@ outputs:
         # skip tests that raise SIGINT and crash the test suite
         {% set tests_to_skip = tests_to_skip + " or (test_csv and test_cancellation)" %}  # [linux]
         {% set tests_to_skip = tests_to_skip + " or (test_flight and test_interrupt)" %}  # [linux]
+        # tests that risk crashing the agent due to intentional out-of-bound memory writes
+        {% set tests_to_skip = tests_to_skip + " or test_debug_memory_pool" %}            # [aarch64 or ppc64le]
         # cannot pass -D_LIBCPP_DISABLE_AVAILABILITY to test suite for our older macos sdk
         {% set tests_to_skip = tests_to_skip + " or test_cpp_extension_in_python" %}      # [osx]
         # skip tests that make invalid(-for-conda) assumptions about the compilers setup

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -391,6 +391,9 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or (test_memory and test_env_var)" %}    # [unix]
         # test is broken; header is in $PREFIX, not $SP_DIR
         {% set tests_to_skip = tests_to_skip + " or (test_misc and test_get_include)" %}  # [unix]
+        # flaky tests that fail occasionally
+        {% set tests_to_skip = tests_to_skip + " or test_total_bytes_allocated " %}       # [linux]
+        {% set tests_to_skip = tests_to_skip + " or test_feather_format " %}              # [linux]
         # ^^^^^^^ TESTS THAT SHOULDN'T HAVE TO BE SKIPPED ^^^^^^^
         - pytest -rfEs -k "not ({{ tests_to_skip }})"
 


### PR DESCRIPTION
Test runs on aarch and ppc have been really crashy recently. Turns out they all point to the exact same tests (even though the error shown in azure implies otherwise):
```
test_memory.py ..............FEEEEE                                      [ 36%]
```

Let's just skip those. Also added a few tests that fail occasionally, but regularly enough to be annoying. There's also the occasional error on windows where something like `with tempfile.TemporaryDirectory() as tempdir2:` can fail upon resource destruction with:
```
E    PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\VSSADM~1\\AppData\\Local\\Temp\\tmpdw6ktuts\\x\\part-0.arrow'
```
These however happen pretty much anywhere, and while very annoying, aren't really worth wholesale skipping these tests over.