### PR TITLE
Test dependencies expansion

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -370,6 +370,8 @@ outputs:
       source_files:
         - testing/data
       commands:
+        - cd ${SP_DIR}                                      # [unix]
+        - cd %SP_DIR%                                       # [win]
         - export ARROW_TEST_DATA="${SRC_DIR}/testing/data"  # [unix]
         - set "ARROW_TEST_DATA=%SRC_DIR%\testing\data"      # [win]
 
@@ -394,7 +396,7 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or test_safe_cast_from_float_with_nans_to_int" %}  # [ppc64le]
         {% set tests_to_skip = tests_to_skip + " or test_float_with_null_as_integer" %}             # [ppc64le]
         # ^^^^^^^ TESTS THAT SHOULDN'T HAVE TO BE SKIPPED ^^^^^^^
-        - pytest --pyargs pyarrow -rfEs -k "not ({{ tests_to_skip }})"
+        - pytest pyarrow/ -rfEs -k "not ({{ tests_to_skip }})"
     {% endif %}
 
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -389,6 +389,8 @@ outputs:
         # skip tests that cannot succeed in emulation
         {% set tests_to_skip = tests_to_skip + " or test_debug_memory_pool_disabled" %}   # [aarch64 or ppc64le]
         {% set tests_to_skip = tests_to_skip + " or test_env_var_io_thread_count" %}      # [aarch64 or ppc64le]
+        # XMinioInvalidObjectName on win: "Object name contains unsupported characters"
+        {% set tests_to_skip = tests_to_skip + " or test_write_to_dataset_with_partitions_s3fs" %}  # [win]
         # vvvvvvv TESTS THAT SHOULDN'T HAVE TO BE SKIPPED vvvvvvv
         # new fsspec changed behaviour, see https://github.com/apache/arrow/issues/37555
         {% set tests_to_skip = tests_to_skip + " or test_get_file_info_with_selector" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -354,6 +354,7 @@ outputs:
         - fastparquet
         - fsspec
         - hypothesis
+        - minio-server
         - pandas
         - scipy
         # these are generally (far) behind on migrating abseil/grpc/protobuf,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -378,8 +378,6 @@ outputs:
         # skip tests that raise SIGINT and crash the test suite
         {% set tests_to_skip = tests_to_skip + " or (test_csv and test_cancellation)" %}  # [linux]
         {% set tests_to_skip = tests_to_skip + " or (test_flight and test_interrupt)" %}  # [linux]
-        # cannot pass -D_LIBCPP_DISABLE_AVAILABILITY to test suite for our older macos sdk
-        {% set tests_to_skip = tests_to_skip + " or test_cpp_extension_in_python" %}      # [osx]
         # skip tests that make invalid(-for-conda) assumptions about the compilers setup
         {% set tests_to_skip = tests_to_skip + " or test_cython_api" %}                   # [unix]
         {% set tests_to_skip = tests_to_skip + " or test_visit_strings" %}                # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -348,6 +348,7 @@ outputs:
         - pytest
         - pytest-lazy-fixture
         - backports.zoneinfo     # [py<39]
+        - boto3
         - cffi
         - cloudpickle
         - cython <3
@@ -356,6 +357,7 @@ outputs:
         - hypothesis
         - minio-server
         - pandas
+        - s3fs
         - scipy
         # these are generally (far) behind on migrating abseil/grpc/protobuf,
         # and using them as test dependencies blocks the migrator unnecessarily


### PR DESCRIPTION
Pick up some changes from in-flight #1170; minio made it into conda-forge very recently, and `sparse` doesn't seem to cause segfaults anymore.