### PR TITLE
[12.x] Backport critical fix for S3 finalization from GH-38375

### DIFF
--- a/.ci_support/migrations/aws_crt_cpp0244.yaml
+++ b/.ci_support/migrations/aws_crt_cpp0244.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  automerge: true
-aws_crt_cpp:
-- 0.24.4
-migrator_ts: 1698267340.0933821

--- a/.ci_support/migrations/aws_sdk_cpp111182.yaml
+++ b/.ci_support/migrations/aws_sdk_cpp111182.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-aws_sdk_cpp:
-- 1.11.182
-migrator_ts: 1697695685.8141418

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,14 @@ source:
     patches:
       # backport https://github.com/apache/arrow/pull/38265
       - patches/0001-GH-38263-C-Prefer-to-call-string_view-data-instead-o.patch
+      - patches/0002-GH-38364-Python-Initialize-S3-on-first-use-38375.patch
   # testing-submodule not part of release tarball
   - git_url: https://github.com/apache/arrow-testing.git
     git_rev: 47f7b56b25683202c1fd957668e13f2abafc0f12
     folder: testing
 
 build:
-  number: 21
+  number: 22
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]

--- a/recipe/patches/0002-GH-38364-Python-Initialize-S3-on-first-use-38375.patch
+++ b/recipe/patches/0002-GH-38364-Python-Initialize-S3-on-first-use-38375.patch
@@ -1,0 +1,144 @@
+From 9d78cbff867e02b391dec0fb6c7f95d0052854e3 Mon Sep 17 00:00:00 2001
+From: Peter Andreas Entschev <peter@entschev.com>
+Date: Tue, 24 Oct 2023 17:42:06 +0200
+Subject: [PATCH 1/2] GH-38364: [Python] Initialize S3 on first use (#38375)
+
+### Rationale for this change
+
+In accordance to https://github.com/apache/arrow/issues/38364, we believe that for various reasons (shortening import time, preventing unnecessary resource consumption and potential bugs with S3 library) it is appropriate to avoid initialization of S3 resources at import time and move that step to occur at first-use.
+
+### What changes are included in this PR?
+
+- Remove calls to `ensure_s3_initialized()` that were up until now executed during `import pyarrow.fs`;
+- Move `ensure_s3_intialized()` calls to `python/pyarrow/_s3fs.pyx` module;
+- Add global flag to mark whether S3 has been previously initialized and `atexit` handlers registered.
+
+### Are these changes tested?
+
+Yes, existing S3 tests check whether it has been initialized, otherwise failing with a C++ exception.
+
+### Are there any user-facing changes?
+
+No, the behavior is now slightly different with S3 initialization not happening immediately after `pyarrow.fs` is imported, but no changes are expected from a user perspective relying on the public API alone.
+
+**This PR contains a "Critical Fix".**
+A bug in aws-sdk-cpp reported in https://github.com/aws/aws-sdk-cpp/issues/2681 causes segmentation faults under specific circumstances when Python processes shutdown, specifically observed with Dask+GPUs (so far we were unable to pinpoint the exact correlation of Dask+GPUs+S3). While this definitely doesn't seem to affect all users and is not directly sourced in Arrow, it may affect use cases that are completely independent of S3 to operate, which is particularly problematic in CI where all tests pass successfully but the process crashes at shutdown.
+* Closes: #38364
+
+Lead-authored-by: Peter Andreas Entschev <peter@entschev.com>
+Co-authored-by: Antoine Pitrou <pitrou@free.fr>
+Signed-off-by: Antoine Pitrou <antoine@python.org>
+---
+ python/pyarrow/_s3fs.pyx                | 9 +++++++++
+ python/pyarrow/fs.py                    | 9 ++++++---
+ python/pyarrow/includes/libarrow_fs.pxd | 1 +
+ 3 files changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/python/pyarrow/_s3fs.pyx b/python/pyarrow/_s3fs.pyx
+index 766caccd5..7979286ea 100644
+--- a/python/pyarrow/_s3fs.pyx
++++ b/python/pyarrow/_s3fs.pyx
+@@ -68,6 +68,13 @@ def finalize_s3():
+     check_status(CFinalizeS3())
+ 
+ 
++def ensure_s3_finalized():
++    """
++    Finalize S3 if already initialized
++    """
++    check_status(CEnsureS3Finalized())
++
++
+ def resolve_s3_region(bucket):
+     """
+     Resolve the S3 region of a bucket.
+@@ -91,6 +98,8 @@ def resolve_s3_region(bucket):
+         c_string c_bucket
+         c_string c_region
+ 
++    ensure_s3_initialized()
++
+     c_bucket = tobytes(bucket)
+     with nogil:
+         c_region = GetResultValue(ResolveS3BucketRegion(c_bucket))
+diff --git a/python/pyarrow/fs.py b/python/pyarrow/fs.py
+index 567bea8ac..7f60fa8bb 100644
+--- a/python/pyarrow/fs.py
++++ b/python/pyarrow/fs.py
+@@ -54,13 +54,16 @@ try:
+     from pyarrow._s3fs import (  # noqa
+         AwsDefaultS3RetryStrategy, AwsStandardS3RetryStrategy,
+         S3FileSystem, S3LogLevel, S3RetryStrategy, ensure_s3_initialized,
+-        finalize_s3, initialize_s3, resolve_s3_region)
++        finalize_s3, ensure_s3_finalized, initialize_s3, resolve_s3_region)
+ except ImportError:
+     _not_imported.append("S3FileSystem")
+ else:
+-    ensure_s3_initialized()
++    # GH-38364: we don't initialize S3 eagerly as that could lead
++    # to crashes at shutdown even when S3 isn't used.
++    # Instead, S3 is initialized lazily using `ensure_s3_initialized`
++    # in assorted places.
+     import atexit
+-    atexit.register(finalize_s3)
++    atexit.register(ensure_s3_finalized)
+ 
+ 
+ def __getattr__(name):
+diff --git a/python/pyarrow/includes/libarrow_fs.pxd b/python/pyarrow/includes/libarrow_fs.pxd
+index 0b683e613..892b652dd 100644
+--- a/python/pyarrow/includes/libarrow_fs.pxd
++++ b/python/pyarrow/includes/libarrow_fs.pxd
+@@ -211,6 +211,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
+         const CS3GlobalOptions& options)
+     cdef CStatus CEnsureS3Initialized "arrow::fs::EnsureS3Initialized"()
+     cdef CStatus CFinalizeS3 "arrow::fs::FinalizeS3"()
++    cdef CStatus CEnsureS3Finalized "arrow::fs::EnsureS3Finalized"()
+ 
+     cdef CResult[c_string] ResolveS3BucketRegion(const c_string& bucket)
+ 
+-- 
+2.42.0
+
+From 1f86050a4b9cc545d04dbea2700a143816a1dbb1 Mon Sep 17 00:00:00 2001
+From: Peter Andreas Entschev <peter@entschev.com>
+Date: Fri, 27 Oct 2023 01:54:00 -0700
+Subject: [PATCH 2/2] Adaptations for Arrow 12
+
+---
+ python/pyarrow/_s3fs.pyx | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/python/pyarrow/_s3fs.pyx b/python/pyarrow/_s3fs.pyx
+index 7979286ea..2ad879dd9 100644
+--- a/python/pyarrow/_s3fs.pyx
++++ b/python/pyarrow/_s3fs.pyx
+@@ -261,6 +261,25 @@ cdef class S3FileSystem(FileSystem):
+                  load_frequency=900, proxy_options=None,
+                  allow_bucket_creation=False, allow_bucket_deletion=False,
+                  retry_strategy: S3RetryStrategy = AwsStandardS3RetryStrategy(max_attempts=3)):
++        ensure_s3_initialized()
++
++        self._initialize_s3(access_key=access_key, secret_key=secret_key, session_token=session_token,
++                            anonymous=anonymous, region=region, request_timeout=request_timeout,
++                            connect_timeout=connect_timeout, scheme=scheme, endpoint_override=endpoint_override,
++                            background_writes=background_writes, default_metadata=default_metadata,
++                            role_arn=role_arn, session_name=session_name, external_id=external_id,
++                            load_frequency=load_frequency, proxy_options=proxy_options,
++                            allow_bucket_creation=allow_bucket_creation, allow_bucket_deletion=allow_bucket_deletion,
++                            retry_strategy=retry_strategy)
++
++    def _initialize_s3(self, *, access_key=None, secret_key=None, session_token=None,
++                       bint anonymous=False, region=None, request_timeout=None,
++                       connect_timeout=None, scheme=None, endpoint_override=None,
++                       bint background_writes=True, default_metadata=None,
++                       role_arn=None, session_name=None, external_id=None,
++                       load_frequency=900, proxy_options=None,
++                       allow_bucket_creation=False, allow_bucket_deletion=False,
++                       retry_strategy: S3RetryStrategy = AwsStandardS3RetryStrategy(max_attempts=3)):
+         cdef:
+             CS3Options options
+             shared_ptr[CS3FileSystem] wrapped
+-- 
+2.42.0
+


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Backport of https://github.com/conda-forge/arrow-cpp-feedstock/pull/1211 for Arrow 12 with [additional changes](https://github.com/conda-forge/arrow-cpp-feedstock/compare/12.x...pentschev:12.x-s3fs-init-on-use?expand=1#diff-114bea9fc3d55b1a0f06c35e540c16426d01cd2fd464cfbe03fcdb0ffb293db8R103-R144) required for Arrow < 13.