### PR TITLE
[12.x] Rebuild for aws_crt_cpp 0.26.2, aws_sdk_cpp 1.11.267

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version11.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.2.yaml
@@ -1,7 +1,7 @@
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -1,7 +1,7 @@
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/linux_aarch64_cuda_compiler_version11.2.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version11.2.yaml
@@ -1,9 +1,9 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
@@ -1,9 +1,9 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/linux_ppc64le_cuda_compiler_version11.2.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_version11.2.yaml
@@ -1,7 +1,7 @@
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compiler_versionNone.yaml
@@ -1,7 +1,7 @@
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/migrations/aws_crt_cpp0262.yaml
+++ b/.ci_support/migrations/aws_crt_cpp0262.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws_crt_cpp 0.26.2
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_crt_cpp:
+- 0.26.2
+migrator_ts: 1707972164.8484967

--- a/.ci_support/migrations/aws_sdk_cpp111267.yaml
+++ b/.ci_support/migrations/aws_sdk_cpp111267.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws_sdk_cpp 1.11.267
+  kind: version
+  migration_number: 1
+aws_sdk_cpp:
+- 1.11.267
+migrator_ts: 1708161269.8562574

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,9 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,9 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/win_64_cuda_compiler_version11.2.yaml
+++ b/.ci_support/win_64_cuda_compiler_version11.2.yaml
@@ -1,7 +1,7 @@
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/.ci_support/win_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNone.yaml
@@ -1,7 +1,7 @@
 aws_crt_cpp:
-- 0.26.1
+- 0.26.2
 aws_sdk_cpp:
-- 1.11.242
+- 1.11.267
 bzip2:
 - '1'
 c_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     folder: testing
 
 build:
-  number: 36
+  number: 37
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]


### PR DESCRIPTION
Collected backport of
#1306 
#1307 
~#1308~ glog deferred due to https://github.com/conda-forge/glog-feedstock/issues/26

Waiting for builds from https://github.com/conda-forge/aws-sdk-cpp-feedstock/pull/842