### PR TITLE
Switch to more specific (=smaller) bindings for GCP

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,28 +8,28 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10:
-        CONFIG: linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10
+      linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10:
+        CONFIG: linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
-      linux_64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12:
-        CONFIG: linux_64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12
+      linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12:
+        CONFIG: linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10:
-        CONFIG: linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10
+      linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10:
+        CONFIG: linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
-      linux_aarch64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12:
-        CONFIG: linux_aarch64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12
+      linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12:
+        CONFIG: linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10:
-        CONFIG: linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10
+      linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10:
+        CONFIG: linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
-      linux_ppc64le_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12:
-        CONFIG: linux_ppc64le_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12
+      linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12:
+        CONFIG: linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 aws_crt_cpp:
 - 0.26.2
 aws_sdk_cpp:
@@ -9,9 +7,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
-cdt_arch:
-- aarch64
+- '10'
 cdt_name:
 - cos7
 channel_sources:
@@ -19,25 +15,27 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.2'
 cuda_compiler_version_min:
 - '11.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cuda:11.2
 gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:
@@ -69,7 +67,7 @@ re2:
 snappy:
 - '1'
 target_platform:
-- linux-aarch64
+- linux-64
 thrift_cpp:
 - 0.19.0
 ucx:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -30,10 +30,12 @@ gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -34,10 +34,12 @@ gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -1,3 +1,5 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 aws_crt_cpp:
 - 0.26.2
 aws_sdk_cpp:
@@ -7,7 +9,9 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '12'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -15,25 +19,27 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
-- '11.2'
+- None
 cuda_compiler_version_min:
 - '11.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.2
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:
@@ -65,7 +71,7 @@ re2:
 snappy:
 - '1'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 thrift_cpp:
 - 0.19.0
 ucx:

--- a/.ci_support/linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '10'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,25 +15,27 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.2'
 cuda_compiler_version_min:
 - '11.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cuda:11.2
 gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,25 +15,27 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
-- '11.2'
+- None
 cuda_compiler_version_min:
 - '11.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.2
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:
@@ -65,7 +67,7 @@ re2:
 snappy:
 - '1'
 target_platform:
-- linux-64
+- linux-ppc64le
 thrift_cpp:
 - 0.19.0
 ucx:

--- a/.ci_support/migrations/libgoogle_cloud217.yaml
+++ b/.ci_support/migrations/libgoogle_cloud217.yaml
@@ -1,0 +1,46 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libgoogle_cloud 2.17
+  kind: version
+  migration_number: 1
+google_cloud_cpp:  # legacy setup
+  - '2.17'
+libgoogle_cloud:   # legacy setup
+  - '2.17'
+libgoogle_cloud_devel:
+  - '2.17'
+libgoogle_cloud_all_devel:
+  - '2.17'
+libgoogle_cloud_aiplatform_devel:
+  - '2.17'
+libgoogle_cloud_automl_devel:
+  - '2.17'
+libgoogle_cloud_bigquery_devel:
+  - '2.17'
+libgoogle_cloud_bigtable_devel:
+  - '2.17'
+libgoogle_cloud_compute_devel:
+  - '2.17'
+libgoogle_cloud_dialogflow_cx_devel:
+  - '2.17'
+libgoogle_cloud_dialogflow_es_devel:
+  - '2.17'
+libgoogle_cloud_discoveryengine_devel:
+  - '2.17'
+libgoogle_cloud_dlp_devel:
+  - '2.17'
+libgoogle_cloud_iam_devel:
+  - '2.17'
+libgoogle_cloud_oauth2_devel:
+  - '2.17'
+libgoogle_cloud_policytroubleshooter_devel:
+  - '2.17'
+libgoogle_cloud_pubsub_devel:
+  - '2.17'
+libgoogle_cloud_spanner_devel:
+  - '2.17'
+libgoogle_cloud_speech_devel:
+  - '2.17'
+libgoogle_cloud_storage_devel:
+  - '2.17'
+migrator_ts: 1707797637.7854993

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,15 +19,17 @@ cuda_compiler_version:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,15 +19,17 @@ cuda_compiler_version:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNone.yaml
@@ -22,14 +22,14 @@ gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
 libcrc32c:
 - '1.1'
-libcurl:
-- '8'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.2.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.2.yaml
@@ -22,14 +22,14 @@ gflags:
 - '2.2'
 glog:
 - '0.6'
-google_cloud_cpp:
-- '2.12'
 libabseil:
 - '20230802'
 libcrc32c:
 - '1.1'
-libcurl:
-- '8'
+libgoogle_cloud_devel:
+- '2.17'
+libgoogle_cloud_storage_devel:
+- '2.17'
 libgrpc:
 - '1.60'
 libprotobuf:

--- a/README.md
+++ b/README.md
@@ -139,45 +139,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10</td>
+              <td>linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12</td>
+              <td>linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10</td>
+              <td>linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12</td>
+              <td>linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10</td>
+              <td>linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12</td>
+              <td>linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=54&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arrow-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,7 +6,6 @@ bot:
   - 14.x
   - 13.x
   - 12.x
-  - 11.0.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 # keep this in sync with llvm_version in meta.yaml;
 # don't rely on global pinning even if it matches
 c_compiler_version:            # [osx]
-  - 15                         # [osx]
+  - 16                         # [osx]
 cxx_compiler_version:          # [osx]
-  - 15                         # [osx]
+  - 16                         # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set build_ext_version = "5.0.0" %}
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}
 {% set proc_build_number = "0" %}
-{% set llvm_version = "15" %}
+{% set llvm_version = "16" %}
 
 # see https://github.com/apache/arrow/blob/apache-arrow-10.0.1/cpp/CMakeLists.txt#L88-L90
 {% set so_version = (version.split(".")[0] | int * 100 + version.split(".")[1] | int) ~ "." ~ version.split(".")[2] ~ ".0" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,11 +65,12 @@ requirements:
     # - proto-opentelemetry-proto =={{ cpp_opentelemetry_sdk }}
     - gflags
     - glog
-    - google-cloud-cpp
     # arrow uses a customized jemalloc, see #944
     # - jemalloc
     - libabseil
     - libboost-headers
+    - libgoogle-cloud-devel
+    - libgoogle-cloud-storage-devel
     - libgrpc
     - libutf8proc
     - lz4-c
@@ -191,10 +192,11 @@ outputs:
         # - proto-opentelemetry-proto =={{ cpp_opentelemetry_sdk }}
         - gflags
         - glog
-        - google-cloud-cpp
         # arrow uses a customized jemalloc, see #944
         # - jemalloc
         - libabseil
+        - libgoogle-cloud-devel
+        - libgoogle-cloud-storage-devel
         - libutf8proc
         - lz4-c
         - openssl    # [win]
@@ -204,7 +206,7 @@ outputs:
         - zlib
         - zstd
         - __cuda >={{ cuda_compiler_version_min }}  # [cuda_compiler_version != "None"]
-        # since libgoogle-cloud is static on windows, see
+        # since libgoogle-cloud{,-storage} is static on windows, see
         # https://github.com/conda-forge/google-cloud-cpp-feedstock/pull/108,
         # its host deps (which aren't yet covered above) leak into the build here
         - libcrc32c  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ source:
     patches:
       # workaround for https://github.com/apache/arrow/issues/37692
       - patches/0001-fixture-teardown-should-not-fail-test.patch
+      # backport https://github.com/apache/arrow/pull/40150 to unpin setuptools-scm
+      - patches/0002-Revert-GH-37803-CI-Dev-Python-Release-and-merge-scri.patch
   # testing-submodule not part of release tarball
   - git_url: https://github.com/apache/arrow-testing.git
     git_rev: ad82a736c170e97b7c8c035ebd8a801c17eec170

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,6 @@ package:
   version: {{ version }}
 
 source:
-  # arrow has the unfortunate habit of changing tags of X.0.0 in the
-  # lead-up until release -> don't use github sources on main
-  # - url: https://github.com/apache/arrow/archive/refs/tags/apache-arrow-{{ version }}.tar.gz
   - url: https://www.apache.org/dyn/closer.lua/arrow/arrow-{{ version }}/apache-arrow-{{ version }}.tar.gz?action=download
     fn: apache-arrow-{{ version }}.tar.gz
     sha256: 01dd3f70e85d9b5b933ec92c0db8a4ef504a5105f78d2d8622e84279fb45c25d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     folder: testing
 
 build:
-  number: 4
+  number: 5
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -491,6 +491,7 @@ outputs:
         - openssl
         - re2
         - zlib  # [win]
+        - zstd  # [win]
       run:
         - {{ pin_subpackage("libarrow", exact=True) }}
       # run-constraints handled by libarrow, since we depend on it with exact=True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -655,8 +655,7 @@ outputs:
         - numpy
         - python
         - setuptools
-        # see https://github.com/apache/arrow/issues/37931
-        - setuptools_scm <8
+        - setuptools-scm
       run:
         # full set of libs because run-exports from libarrow-all aren't picked up
         - {{ pin_subpackage("libarrow", exact=True) }}
@@ -747,8 +746,7 @@ outputs:
         - numpy
         - python
         - setuptools
-        # see https://github.com/apache/arrow/issues/37931
-        - setuptools_scm <8
+        - setuptools-scm
       run:
         - {{ pin_subpackage('pyarrow', exact=True) }}
         - python

--- a/recipe/patches/0001-fixture-teardown-should-not-fail-test.patch
+++ b/recipe/patches/0001-fixture-teardown-should-not-fail-test.patch
@@ -1,14 +1,14 @@
-From 22be2a20e6a4b7fa7e8ac2b2723240c4d288e3ed Mon Sep 17 00:00:00 2001
+From d1ea231aeb2daa8c742effae14e1ee9f011833c9 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 13 Sep 2023 21:34:29 +1100
-Subject: [PATCH 3/3] fixture teardown should not fail test
+Subject: [PATCH 1/2] fixture teardown should not fail test
 
 ---
  python/pyarrow/tests/test_fs.py | 10 ++++++++--
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/python/pyarrow/tests/test_fs.py b/python/pyarrow/tests/test_fs.py
-index c540bf968..430fd7ece 100644
+index d0fa253e3..de179855d 100644
 --- a/python/pyarrow/tests/test_fs.py
 +++ b/python/pyarrow/tests/test_fs.py
 @@ -255,7 +255,10 @@ def s3fs(request, s3_server):

--- a/recipe/patches/0002-Revert-GH-37803-CI-Dev-Python-Release-and-merge-scri.patch
+++ b/recipe/patches/0002-Revert-GH-37803-CI-Dev-Python-Release-and-merge-scri.patch
@@ -1,0 +1,135 @@
+From 1c34f1ef9759cbad61546947f41e8f055cae20bb Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 20 Feb 2024 13:01:37 +1100
+Subject: [PATCH 2/2] Revert "GH-37803: [CI][Dev][Python] Release and merge
+ script errors (#37819)"
+
+This reverts commit 79e49dbfb71efc70555417ba19cb612eb50924e8.
+---
+ ci/conda_env_archery.txt                    | 2 +-
+ ci/conda_env_crossbow.txt                   | 2 +-
+ ci/conda_env_python.txt                     | 2 +-
+ dev/archery/setup.py                        | 2 +-
+ dev/tasks/conda-recipes/arrow-cpp/meta.yaml | 4 ++--
+ python/pyproject.toml                       | 2 +-
+ python/requirements-build.txt               | 2 +-
+ python/requirements-wheel-build.txt         | 2 +-
+ python/setup.py                             | 2 +-
+ 9 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/ci/conda_env_archery.txt b/ci/conda_env_archery.txt
+index 40875e0a5..ace7a42ac 100644
+--- a/ci/conda_env_archery.txt
++++ b/ci/conda_env_archery.txt
+@@ -25,7 +25,7 @@ jira
+ pygit2
+ pygithub
+ ruamel.yaml
+-setuptools_scm<8.0.0
++setuptools_scm
+ toolz
+ 
+ # benchmark
+diff --git a/ci/conda_env_crossbow.txt b/ci/conda_env_crossbow.txt
+index 59b799720..347294650 100644
+--- a/ci/conda_env_crossbow.txt
++++ b/ci/conda_env_crossbow.txt
+@@ -21,5 +21,5 @@ jinja2
+ jira
+ pygit2
+ ruamel.yaml
+-setuptools_scm<8.0.0
++setuptools_scm
+ toolz
+diff --git a/ci/conda_env_python.txt b/ci/conda_env_python.txt
+index 972034421..4018ed200 100644
+--- a/ci/conda_env_python.txt
++++ b/ci/conda_env_python.txt
+@@ -28,4 +28,4 @@ pytest-faulthandler
+ pytest-lazy-fixture
+ s3fs>=2023.10.0
+ setuptools
+-setuptools_scm<8.0.0
++setuptools_scm
+diff --git a/dev/archery/setup.py b/dev/archery/setup.py
+index 2ecc72e04..02a8b3429 100755
+--- a/dev/archery/setup.py
++++ b/dev/archery/setup.py
+@@ -30,7 +30,7 @@ jinja_req = 'jinja2>=2.11'
+ extras = {
+     'benchmark': ['pandas'],
+     'crossbow': ['github3.py', jinja_req, 'pygit2>=1.6.0', 'requests',
+-                 'ruamel.yaml', 'setuptools_scm<8.0.0'],
++                 'ruamel.yaml', 'setuptools_scm'],
+     'crossbow-upload': ['github3.py', jinja_req, 'ruamel.yaml',
+                         'setuptools_scm'],
+     'docker': ['ruamel.yaml', 'python-dotenv'],
+diff --git a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+index b8ffbfdb7..8ceada1af 100644
+--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
++++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+@@ -240,7 +240,7 @@ outputs:
+         - numpy
+         - python
+         - setuptools
+-        - setuptools_scm <8.0.0
++        - setuptools_scm
+       run:
+         - {{ pin_subpackage('libarrow', exact=True) }}
+         - {{ pin_compatible('numpy') }}
+@@ -322,7 +322,7 @@ outputs:
+         - numpy
+         - python
+         - setuptools
+-        - setuptools_scm <8.0.0
++        - setuptools_scm
+       run:
+         - {{ pin_subpackage('pyarrow', exact=True) }}
+         - python
+diff --git a/python/pyproject.toml b/python/pyproject.toml
+index 437de105a..fe8c938a9 100644
+--- a/python/pyproject.toml
++++ b/python/pyproject.toml
+@@ -19,7 +19,7 @@
+ requires = [
+     "cython >= 0.29.31",
+     "oldest-supported-numpy>=0.14",
+-    "setuptools_scm < 8.0.0",
++    "setuptools_scm",
+     "setuptools >= 40.1.0",
+     "wheel"
+ ]
+diff --git a/python/requirements-build.txt b/python/requirements-build.txt
+index 56e9d479e..507e90813 100644
+--- a/python/requirements-build.txt
++++ b/python/requirements-build.txt
+@@ -1,4 +1,4 @@
+ cython>=0.29.31
+ oldest-supported-numpy>=0.14
+-setuptools_scm<8.0.0
++setuptools_scm
+ setuptools>=38.6.0
+diff --git a/python/requirements-wheel-build.txt b/python/requirements-wheel-build.txt
+index f42ee4a01..6043d2ffb 100644
+--- a/python/requirements-wheel-build.txt
++++ b/python/requirements-wheel-build.txt
+@@ -1,5 +1,5 @@
+ cython>=0.29.31
+ oldest-supported-numpy>=0.14
+-setuptools_scm<8.0.0
++setuptools_scm
+ setuptools>=58
+ wheel
+diff --git a/python/setup.py b/python/setup.py
+index eb9f72ac3..49e2dea15 100755
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -492,7 +492,7 @@ setup(
+                                  'pyarrow/_generated_version.py'),
+         'version_scheme': guess_next_dev_version
+     },
+-    setup_requires=['setuptools_scm < 8.0.0', 'cython >= 0.29.31'] + setup_requires,
++    setup_requires=['setuptools_scm', 'cython >= 0.29.31'] + setup_requires,
+     install_requires=install_requires,
+     tests_require=['pytest', 'pandas', 'hypothesis'],
+     python_requires='>=3.8',


### PR DESCRIPTION
This needed a bunch of work on the google-cloud-cpp side (see [here](https://github.com/conda-forge/google-cloud-cpp-feedstock/issues/141)), but now we should hopefully be able to reap the benefits!

Closes #1305 

~Currently based on #1312, draft until that goes in.~