### PR TITLE
Rebuild for aws_crt_cpp 0.26.8

### DIFF
--- a/.ci_support/linux_64_c_compiler_version10c_stdlib_version2.17cuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_c_compiler_version10c_stdlib_version2.17cuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -1,5 +1,5 @@
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_c_compiler_version12c_stdlib_version2.12cuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -1,5 +1,5 @@
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -1,5 +1,5 @@
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -1,5 +1,5 @@
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/migrations/aws_crt_cpp0268.yaml
+++ b/.ci_support/migrations/aws_crt_cpp0268.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws_crt_cpp 0.26.8
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_crt_cpp:
+- 0.26.8
+migrator_ts: 1713020524.6837494

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNone.yaml
@@ -1,5 +1,5 @@
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.2.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.2.yaml
@@ -1,5 +1,5 @@
 aws_crt_cpp:
-- 0.26.6
+- 0.26.8
 aws_sdk_cpp:
 - 1.11.267
 bzip2:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     folder: testing
 
 build:
-  number: 5
+  number: 6
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/5815

The migration for [aws_crt_cpp 0.26.8](https://conda-forge.org/status/migration/aws_crt_cpp0268) failed for arrow-cpp-feedstock because the rerendering took longer than the limit of 900 seconds. I applied the migration locally.