### PR TITLE
TEST: arrow v25.0.0 (end-to-end)

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,7 +14,7 @@ jobs:
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
-        pagefile_size: 0
+        pagefile_size: 16
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
@@ -24,7 +24,7 @@ jobs:
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
-        pagefile_size: 0
+        pagefile_size: 16
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -13,7 +13,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: C:\bld
         free_disk_space: skip
-        pagefile_size: 0
+        pagefile_size: 16
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: C:\Miniforge
@@ -22,7 +22,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: C:\bld
         free_disk_space: skip
-        pagefile_size: 0
+        pagefile_size: 16
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: C:\Miniforge
@@ -31,6 +31,11 @@ jobs:
     UPLOAD_TEMP: D:\\tmp
 
   steps:
+    - script: |
+        call ".scripts\create_pagefile.bat" $(pagefile_size)
+      env:
+        CONDA_BLD_PATH: $(build_workspace_dir)
+      displayName: Create page file
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build

--- a/.ci_support/linux_64_cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.9.yaml
@@ -42,6 +42,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -64,10 +66,18 @@ libutf8proc:
 - '2.11'
 lz4_c:
 - '1.10'
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -42,6 +42,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -64,10 +66,18 @@ libutf8proc:
 - '2.11'
 lz4_c:
 - '1.10'
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9.yaml
@@ -42,6 +42,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -64,10 +66,18 @@ libutf8proc:
 - '2.11'
 lz4_c:
 - '1.10'
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
@@ -42,6 +42,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -64,10 +66,18 @@ libutf8proc:
 - '2.11'
 lz4_c:
 - '1.10'
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -40,6 +40,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -62,10 +64,18 @@ libutf8proc:
 - '2.11'
 lz4_c:
 - '1.10'
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/migrations/python314.yaml
+++ b/.ci_support/migrations/python314.yaml
@@ -1,0 +1,43 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip;
+migrator_ts: 1724712607
+__migrator:
+    commit_message: Rebuild for python 3.14
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314  # new entry
+    paused: false
+    longterm: true
+    pr_limit: 5
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+    exclude_pinned_pkgs: false
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+    additional_zip_keys:
+        - channel_sources
+
+python:
+- 3.14.* *_cp314
+# additional entries to add for zip_keys
+is_python_min:
+- false
+channel_sources:
+- conda-forge,conda-forge/label/python_rc

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -42,6 +42,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -66,10 +68,18 @@ lz4_c:
 - '1.10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -42,6 +42,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -66,10 +68,18 @@ lz4_c:
 - '1.10'
 macos_machine:
 - arm64-apple-darwin20.0.0
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/win_64_cuda_compiler_version12.9.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9.yaml
@@ -34,6 +34,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -58,10 +60,18 @@ libutf8proc:
 - '2.11'
 lz4_c:
 - '1.10'
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.ci_support/win_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNone.yaml
@@ -34,6 +34,8 @@ gflags:
 - '2.2'
 glog:
 - '0.7'
+is_freethreading:
+- false
 libabseil:
 - '20260107'
 libarrow:
@@ -58,10 +60,18 @@ libutf8proc:
 - '2.11'
 lz4_c:
 - '1.10'
+numpy:
+- '2'
 openssl:
 - '3.5'
 orc:
 - 2.3.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
 re2:
 - 2025.11.05
 snappy:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -30,7 +30,7 @@ jobs:
             docker_run_args: 
             free_disk_space: quick
             os: ubuntu
-            pagefile_size: 0
+            pagefile_size: 16
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
@@ -42,7 +42,7 @@ jobs:
             docker_run_args: 
             free_disk_space: quick
             os: ubuntu
-            pagefile_size: 0
+            pagefile_size: 16
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
@@ -54,7 +54,7 @@ jobs:
             docker_run_args: 
             free_disk_space: quick
             os: ubuntu
-            pagefile_size: 0
+            pagefile_size: 16
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
@@ -66,7 +66,7 @@ jobs:
             docker_run_args: 
             free_disk_space: quick
             os: ubuntu
-            pagefile_size: 0
+            pagefile_size: 16
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
@@ -78,7 +78,7 @@ jobs:
             docker_run_args: 
             free_disk_space: quick
             os: ubuntu
-            pagefile_size: 0
+            pagefile_size: 16
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
@@ -94,6 +94,15 @@ jobs:
       shell: bash
       run: |
         .scripts/free_disk_space.sh "${FREE_DISK_SPACE}"
+
+    - name: Configure page file on Linux
+      if: matrix.os == 'ubuntu' && matrix.pagefile_size > 0
+      shell: bash
+      env:
+        PAGEFILE_SIZE: ${{ matrix.pagefile_size }}
+        GHA_RUNS_ON: ${{ join(matrix.runs_on, ' ') }}
+      run: |
+        .scripts/create_pagefile.sh "${PAGEFILE_SIZE}"
     - name: Configure binfmt_misc
       if: matrix.os == 'ubuntu'
       shell: bash

--- a/.scripts/SetPageFileSize.ps1
+++ b/.scripts/SetPageFileSize.ps1
@@ -1,0 +1,197 @@
+<#
+.SYNOPSIS
+  Configure Pagefile on Windows machine
+.NOTES
+  Author:         Aleksandr Chebotov
+.EXAMPLE
+  SetPageFileSize.ps1 -MinimumSize 4GB -MaximumSize 8GB -DiskRoot "D:"
+#>
+
+# this file taken 1:1 (with the exception of this comment & the parameter echo) from the MIT-licensed
+# https://github.com/al-cheb/configure-pagefile-action/blob/916fa29e5d27bd4e8eef3666869afbaaee27d9eb/scripts/SetPageFileSize.ps1
+
+param(
+    [System.UInt64] $MinimumSize = 8gb ,
+    [System.UInt64] $MaximumSize = 8gb ,
+    [System.String] $DiskRoot = "D:"
+)
+
+# https://referencesource.microsoft.com/#System.IdentityModel/System/IdentityModel/NativeMethods.cs,619688d876febbe1
+# https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/mm/modwrite/create.htm
+# https://referencesource.microsoft.com/#mscorlib/microsoft/win32/safehandles/safefilehandle.cs,9b08210f3be75520
+# https://referencesource.microsoft.com/#mscorlib/system/security/principal/tokenaccesslevels.cs,6eda91f498a38586
+# https://www.autoitscript.com/forum/topic/117993-api-ntcreatepagingfile/
+
+$source = @'
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Text;
+using Microsoft.Win32;
+using Microsoft.Win32.SafeHandles;
+
+namespace Util
+{
+    class NativeMethods
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct LUID
+        {
+            internal uint LowPart;
+            internal uint HighPart;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct LUID_AND_ATTRIBUTES
+        {
+            internal LUID Luid;
+            internal uint Attributes;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TOKEN_PRIVILEGE
+        {
+            internal uint PrivilegeCount;
+            internal LUID_AND_ATTRIBUTES Privilege;
+
+            internal static readonly uint Size = (uint)Marshal.SizeOf(typeof(TOKEN_PRIVILEGE));
+        }
+
+        [StructLayoutAttribute(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct UNICODE_STRING
+        {
+            internal UInt16 length;
+            internal UInt16 maximumLength;
+            internal string buffer;
+        }
+
+        [DllImport("kernel32.dll", SetLastError=true)]
+        internal static extern IntPtr LocalFree(IntPtr handle);
+
+        [DllImport("advapi32.dll", ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true, PreserveSig = false)]
+        internal static extern bool LookupPrivilegeValueW(
+            [In] string lpSystemName,
+            [In] string lpName,
+            [Out] out LUID luid
+        );
+
+        [DllImport("advapi32.dll", SetLastError = true, PreserveSig = false)]
+        internal static extern bool AdjustTokenPrivileges(
+            [In] SafeCloseHandle tokenHandle,
+            [In] bool disableAllPrivileges,
+            [In] ref TOKEN_PRIVILEGE newState,
+            [In] uint bufferLength,
+            [Out] out TOKEN_PRIVILEGE previousState,
+            [Out] out uint returnLength
+        );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = false)]
+        internal static extern bool OpenProcessToken(
+            [In] IntPtr processToken,
+            [In] int desiredAccess,
+            [Out] out SafeCloseHandle tokenHandle
+        );
+
+        [DllImport("ntdll.dll", CharSet = CharSet.Unicode, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern Int32 NtCreatePagingFile(
+            [In] ref UNICODE_STRING pageFileName,
+            [In] ref Int64 minimumSize,
+            [In] ref Int64 maximumSize,
+            [In] UInt32 flags
+        );
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern uint QueryDosDeviceW(
+            string lpDeviceName,
+            StringBuilder lpTargetPath,
+            int ucchMax
+        );
+    }
+
+    public sealed class SafeCloseHandle: SafeHandleZeroOrMinusOneIsInvalid
+    {
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
+        internal extern static bool CloseHandle(IntPtr handle);
+
+        private SafeCloseHandle() : base(true)
+        {
+        }
+
+        public SafeCloseHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        override protected bool ReleaseHandle()
+        {
+            return CloseHandle(handle);
+        }
+    }
+
+    public class PageFile
+    {
+        public static void SetPageFileSize(long minimumValue, long maximumValue, string lpDeviceName)
+        {
+            SetPageFilePrivilege();
+            StringBuilder lpTargetPath = new StringBuilder(260);
+
+            UInt32 resultQueryDosDevice = NativeMethods.QueryDosDeviceW(lpDeviceName, lpTargetPath, lpTargetPath.Capacity);
+            if (resultQueryDosDevice == 0)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            string pageFilePath = lpTargetPath.ToString() + "\\pagefile.sys";
+
+            NativeMethods.UNICODE_STRING pageFileName = new NativeMethods.UNICODE_STRING
+            {
+                length = (ushort)(pageFilePath.Length * 2),
+                maximumLength = (ushort)(2 * (pageFilePath.Length + 1)),
+                buffer = pageFilePath
+            };
+
+            Int32 resultNtCreatePagingFile = NativeMethods.NtCreatePagingFile(ref pageFileName, ref minimumValue, ref maximumValue, 0);
+            if (resultNtCreatePagingFile != 0)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            Console.WriteLine("PageFile: {0} / {1} bytes for {2}", minimumValue, maximumValue, pageFilePath);
+        }
+
+        static void SetPageFilePrivilege()
+        {
+            const int SE_PRIVILEGE_ENABLED = 0x00000002;
+            const int AdjustPrivileges = 0x00000020;
+            const int Query = 0x00000008;
+
+            NativeMethods.LUID luid;
+            NativeMethods.LookupPrivilegeValueW(null, "SeCreatePagefilePrivilege", out luid);
+
+            SafeCloseHandle hToken;
+            NativeMethods.OpenProcessToken(
+                Process.GetCurrentProcess().Handle,
+                AdjustPrivileges | Query,
+                out hToken
+            );
+
+            NativeMethods.TOKEN_PRIVILEGE previousState;
+            NativeMethods.TOKEN_PRIVILEGE newState;
+            uint previousSize = 0;
+            newState.PrivilegeCount = 1;
+            newState.Privilege.Luid = luid;
+            newState.Privilege.Attributes = SE_PRIVILEGE_ENABLED;
+
+            NativeMethods.AdjustTokenPrivileges(hToken, false, ref newState, NativeMethods.TOKEN_PRIVILEGE.Size, out previousState, out previousSize);
+        }
+    }
+}
+'@
+
+Add-Type -TypeDefinition $source
+
+echo Parameters: $minimumSize, $maximumSize, $diskRoot
+# Set SetPageFileSize
+[Util.PageFile]::SetPageFileSize($minimumSize, $maximumSize, $diskRoot)

--- a/.scripts/create_pagefile.bat
+++ b/.scripts/create_pagefile.bat
@@ -1,0 +1,20 @@
+setlocal enableextensions enabledelayedexpansion
+
+set PAGEFILE_SIZE=%1
+
+:: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
+set ThisScriptsDirectory=%~dp0
+set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
+:: Try to use different drive than CONDA_BLD_PATH-location for pagefile, if available
+set PageFileDrive=C:
+if /i "%CONDA_BLD_PATH:~0,2%" == "C:" (
+    if exist D:\ set "PageFileDrive=D:"
+)
+
+echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %PAGEFILE_SIZE% GiB in %PageFileDrive%
+REM Inspired by:
+REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
+REM Drive-letter needs to be escaped in quotes
+PowerShell -NoProfile -ExecutionPolicy Bypass ^
+    -Command "& '%EntryPointPath%' -MinimumSize "%PAGEFILE_SIZE%GB" -MaximumSize "%PAGEFILE_SIZE%GB" -DiskRoot \"%PageFileDrive%\""
+exit /b

--- a/.scripts/create_pagefile.sh
+++ b/.scripts/create_pagefile.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ex
+
+PAGEFILE_SIZE=${1}
+
+SWAPFILE=/swapfile
+if [[ ${GHA_RUNS_ON} == *namespace-profile-* ]]; then
+    SWAPFILE=/namespace/scratch/swapfile
+fi
+# If there is already a swapfile, disable it and remove it
+if swapon --show | grep -q "^${SWAPFILE}"; then
+    sudo swapoff "${SWAPFILE}" || true
+fi
+[[ -f ${SWAPFILE} ]] && sudo rm -f "${SWAPFILE}"
+
+sudo fallocate -l "${PAGEFILE_SIZE}GiB" "${SWAPFILE}"
+sudo chmod 600 "${SWAPFILE}"
+sudo mkswap "${SWAPFILE}"
+sudo swapon "${SWAPFILE}"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,42 @@ Package license: Apache-2.0
 
 Summary: Executables for inspecting Apache Parquet files
 
+About pyarrow
+-------------
+
+Home: http://github.com/apache/arrow
+
+Package license: Apache-2.0
+
+Summary: Python libraries for Apache Arrow with default capabilities
+
+About pyarrow-all
+-----------------
+
+Home: http://github.com/apache/arrow
+
+Package license: Apache-2.0
+
+Summary: Python libraries for Apache Arrow with all capabilities
+
+About pyarrow-core
+------------------
+
+Home: http://github.com/apache/arrow
+
+Package license: Apache-2.0
+
+Summary: Python libraries for Apache Arrow Core
+
+About pyarrow-tests
+-------------------
+
+Home: http://github.com/apache/arrow
+
+Package license: Apache-2.0
+
+Summary: Python test files for Apache Arrow
+
 Current build status
 ====================
 
@@ -213,6 +249,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libarrow--substrait-green.svg)](https://anaconda.org/conda-forge/libarrow-substrait) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libarrow-substrait.svg)](https://anaconda.org/conda-forge/libarrow-substrait) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libarrow-substrait.svg)](https://anaconda.org/conda-forge/libarrow-substrait) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libarrow-substrait.svg)](https://anaconda.org/conda-forge/libarrow-substrait) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libparquet-green.svg)](https://anaconda.org/conda-forge/libparquet) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libparquet.svg)](https://anaconda.org/conda-forge/libparquet) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libparquet.svg)](https://anaconda.org/conda-forge/libparquet) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libparquet.svg)](https://anaconda.org/conda-forge/libparquet) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-parquet--utils-green.svg)](https://anaconda.org/conda-forge/parquet-utils) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/parquet-utils.svg)](https://anaconda.org/conda-forge/parquet-utils) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/parquet-utils.svg)](https://anaconda.org/conda-forge/parquet-utils) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/parquet-utils.svg)](https://anaconda.org/conda-forge/parquet-utils) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pyarrow-green.svg)](https://anaconda.org/conda-forge/pyarrow) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyarrow.svg)](https://anaconda.org/conda-forge/pyarrow) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyarrow.svg)](https://anaconda.org/conda-forge/pyarrow) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyarrow.svg)](https://anaconda.org/conda-forge/pyarrow) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pyarrow--all-green.svg)](https://anaconda.org/conda-forge/pyarrow-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyarrow-all.svg)](https://anaconda.org/conda-forge/pyarrow-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyarrow-all.svg)](https://anaconda.org/conda-forge/pyarrow-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyarrow-all.svg)](https://anaconda.org/conda-forge/pyarrow-all) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pyarrow--core-green.svg)](https://anaconda.org/conda-forge/pyarrow-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyarrow-core.svg)](https://anaconda.org/conda-forge/pyarrow-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyarrow-core.svg)](https://anaconda.org/conda-forge/pyarrow-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyarrow-core.svg)](https://anaconda.org/conda-forge/pyarrow-core) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pyarrow--tests-green.svg)](https://anaconda.org/conda-forge/pyarrow-tests) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyarrow-tests.svg)](https://anaconda.org/conda-forge/pyarrow-tests) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyarrow-tests.svg)](https://anaconda.org/conda-forge/pyarrow-tests) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyarrow-tests.svg)](https://anaconda.org/conda-forge/pyarrow-tests) |
 
 Installing arrow-cpp
 ====================
@@ -224,16 +264,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `apache-arrow-proc, arrow-utils, libarrow, libarrow-acero, libarrow-all, libarrow-compute, libarrow-dataset, libarrow-flight, libarrow-flight-sql, libarrow-gandiva, libarrow-substrait, libparquet, parquet-utils` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `apache-arrow-proc, arrow-utils, libarrow, libarrow-acero, libarrow-all, libarrow-compute, libarrow-dataset, libarrow-flight, libarrow-flight-sql, libarrow-gandiva, libarrow-substrait, libparquet, parquet-utils, pyarrow, pyarrow-all, pyarrow-core, pyarrow-tests` can be installed with `conda`:
 
 ```
-conda install apache-arrow-proc arrow-utils libarrow libarrow-acero libarrow-all libarrow-compute libarrow-dataset libarrow-flight libarrow-flight-sql libarrow-gandiva libarrow-substrait libparquet parquet-utils
+conda install apache-arrow-proc arrow-utils libarrow libarrow-acero libarrow-all libarrow-compute libarrow-dataset libarrow-flight libarrow-flight-sql libarrow-gandiva libarrow-substrait libparquet parquet-utils pyarrow pyarrow-all pyarrow-core pyarrow-tests
 ```
 
 or with `mamba`:
 
 ```
-mamba install apache-arrow-proc arrow-utils libarrow libarrow-acero libarrow-all libarrow-compute libarrow-dataset libarrow-flight libarrow-flight-sql libarrow-gandiva libarrow-substrait libparquet parquet-utils
+mamba install apache-arrow-proc arrow-utils libarrow libarrow-acero libarrow-all libarrow-compute libarrow-dataset libarrow-flight libarrow-flight-sql libarrow-gandiva libarrow-substrait libparquet parquet-utils pyarrow pyarrow-all pyarrow-core pyarrow-tests
 ```
 
 It is possible to list all of the versions of `apache-arrow-proc` available on your platform with `conda`:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -24,6 +24,8 @@ workflow_settings:
   free_disk_space:
   - os: linux
     value: quick
+  pagefile_size:
+  - value: 16
   tools_install_dir:
   - os: win
     value: C:\Miniforge

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -9,7 +9,8 @@ build_platform:
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
-conda_forge_output_validation: true
+# DO NOT MERGE
+conda_forge_output_validation: false
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/build-pyarrow.bat
+++ b/recipe/build-pyarrow.bat
@@ -1,0 +1,40 @@
+@echo on
+
+pushd "%SRC_DIR%"\python
+
+SET ARROW_HOME=%LIBRARY_PREFIX%
+SET SETUPTOOLS_SCM_PRETEND_VERSION=%PKG_VERSION%
+SET PYARROW_WITH_ACERO=1
+set PYARROW_WITH_AZURE=1
+SET PYARROW_WITH_DATASET=1
+SET PYARROW_WITH_FLIGHT=1
+SET PYARROW_WITH_GANDIVA=1
+SET PYARROW_WITH_GCS=1
+SET PYARROW_WITH_HDFS=1
+SET PYARROW_WITH_ORC=1
+SET PYARROW_WITH_PARQUET=1
+SET PYARROW_WITH_PARQUET_ENCRYPTION=1
+SET PYARROW_WITH_S3=1
+SET PYARROW_WITH_SUBSTRAIT=1
+SET CMAKE_GENERATOR=Ninja
+:: Ninja expects no generator platform or toolset
+SET CMAKE_GENERATOR_PLATFORM=
+SET CMAKE_GENERATOR_TOOLSET=
+
+:: Enable CUDA support
+if "%cuda_compiler_version%"=="None" (
+    set "PYARROW_WITH_CUDA=0"
+) else (
+    set "PYARROW_WITH_CUDA=1"
+)
+
+python -m pip install . -vv ^
+    -C build.verbose=true ^
+    -C cmake.build-type=release
+
+if %ERRORLEVEL% neq 0 exit 1
+popd
+
+if [%PKG_NAME%] NEQ [pyarrow-tests] (
+    rd /s /q %SP_DIR%\pyarrow\tests
+)

--- a/recipe/build-pyarrow.sh
+++ b/recipe/build-pyarrow.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -ex
+
+# Build dependencies
+export ARROW_HOME=$PREFIX
+export PARQUET_HOME=$PREFIX
+export SETUPTOOLS_SCM_PRETEND_VERSION=$PKG_VERSION
+export PYARROW_WITH_ACERO=1
+export PYARROW_WITH_AZURE=1
+export PYARROW_WITH_DATASET=1
+export PYARROW_WITH_FLIGHT=1
+export PYARROW_WITH_GANDIVA=1
+export PYARROW_WITH_GCS=1
+export PYARROW_WITH_HDFS=1
+export PYARROW_WITH_ORC=1
+export PYARROW_WITH_PARQUET=1
+export PYARROW_WITH_PARQUET_ENCRYPTION=1
+export PYARROW_WITH_S3=1
+export PYARROW_WITH_SUBSTRAIT=1
+export CMAKE_GENERATOR=Ninja
+BUILD_EXT_FLAGS=""
+
+# Enable CUDA support
+if [[ ! -z "${cuda_compiler_version+x}" && "${cuda_compiler_version}" != "None" ]]; then
+    export PYARROW_WITH_CUDA=1
+    if [[ "${build_platform}" != "${target_platform}" ]]; then
+        export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"
+    fi
+else
+    export PYARROW_WITH_CUDA=0
+fi
+
+# Resolve: Make Error at cmake_modules/SetupCxxFlags.cmake:338 (message): Unsupported arch flag: -march=.
+if [[ "${target_platform}" == "linux-aarch64" ]]; then
+    export PYARROW_CMAKE_OPTIONS="-DARROW_ARMV8_ARCH=armv8-a ${PYARROW_CMAKE_OPTIONS}"
+fi
+
+if [[ "${target_platform}" == osx-* ]]; then
+    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+if [[ "${target_platform}" == "linux-aarch64" ]] || [[ "${target_platform}" == "linux-ppc64le" ]]; then
+    # Limit number of threads used to avoid hardware oversubscription
+    export CMAKE_BUILD_PARALLEL_LEVEL=4
+fi
+
+cd python
+
+python -m pip install . -vv \
+    -C build.verbose=true \
+    -C cmake.build-type=release \
+    -C cmake.args="-DARROW_SIMD_LEVEL=NONE" \
+    -C cmake.args=${PYARROW_CMAKE_OPTIONS}
+
+if [[ "$PKG_NAME" != "pyarrow-tests" ]]; then
+    if [[ "$is_freethreading" == "true" ]]; then
+        # work around https://github.com/conda/conda-build/issues/5563
+        rm -r $PREFIX/lib/python3.14t/site-packages/pyarrow/tests
+    else
+        rm -r ${SP_DIR}/pyarrow/tests
+    fi
+fi
+
+cd ..

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,3 +9,9 @@ c_compiler_version:            # [osx]
   - 21                         # [osx]
 cxx_compiler_version:          # [osx]
   - 21                         # [osx]
+
+# DEBUG
+python:
+  - 3.14.* *_cp314
+is_python_min:
+  - false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -799,6 +799,318 @@ outputs:
         - LICENSE.txt
       summary: Executables for manipulating Apache arrow files
 
+  - name: pyarrow-core
+    script: build-pyarrow.sh   # [unix]
+    script: build-pyarrow.bat  # [win]
+    version: {{ version }}
+    build:
+      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}
+      ignore_run_exports_from:
+        - {{ compiler("cuda") }}                 # [cuda_compiler_version != "None"]
+        - libarrow-all
+        # we don't need numpy at runtime, just to build
+        - numpy
+      rpaths:
+        - lib/
+        - {{ SP_DIR }}/pyarrow
+      missing_dso_whitelist:
+        # not actually missing, but installed into SP_DIR, see tests
+        - '*/arrow_python.dll'                # [win]
+        - '*/arrow_python_flight.dll'         # [win]
+        # pyarrow-core builds with the capabilities but we do not ship them
+        # to provide the smaller core functionality.
+        - 'lib/libarrow_acero.*'              # [unix]
+        - 'lib/libarrow_dataset.*'            # [unix]
+        - 'lib/libarrow_substrait.*'          # [unix]
+        - 'lib/libarrow_flight.*'             # [unix]
+        - 'lib/libparquet.*'                  # [unix]
+        - 'lib/libgandiva.*'                  # [unix]
+        - 'Library/lib/arrow_acero.dll'       # [win]
+        - 'Library/lib/arrow_dataset.dll'     # [win]
+        - 'Library/lib/arrow_substrait.dll'   # [win]
+        - 'Library/lib/arrow_flight.dll'      # [win]
+        - 'Library/lib/parquet.dll'           # [win]
+        - 'Library/lib/gandiva.dll'           # [win]
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ stdlib("c") }}
+        - {{ compiler("cxx") }}
+        # pyarrow does not require nvcc but it needs to link against libraries in libarrow=*=*cuda
+        - {{ compiler("cuda") }}                 # [cuda_compiler_version != "None"]
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - cython                                 # [build_platform != target_platform]
+        - numpy                                  # [build_platform != target_platform]
+        - cmake
+        - ninja
+      host:
+        # We add all libarrow package dependencies on host in order
+        # to build pyarrow once with all capabilities.
+        - libarrow-all {{ version }}.* *{{ build_ext }}
+        - clangdev {{ llvm_version }}
+        - llvmdev {{ llvm_version }}
+        - zlib
+        - cython
+        - libcst
+        - numpy
+        - python
+        - pip
+        - scikit-build-core
+        - setuptools-scm
+      run:
+        # We ignore the run-exports from libarrow-all and restrict to only
+        # libarrow, as we don't want the other libraries to be installed when
+        # running for pyarrow-core, where the aim is a low storage footprint.
+        - libarrow {{ version }}.* *{{ build_ext }}
+        # compute is necessary even for a basic `import pyarrow`
+        - libarrow-compute {{ version }}.* *{{ build_ext }}
+        - python
+      run_constrained:
+        - apache-arrow-proc * {{ build_ext }}
+        # in place of the ignored run-export, keep lower pin aligned with run_exports from numpy
+        # https://github.com/conda-forge/numpy-feedstock/blob/main/recipe/recipe.yaml
+        - numpy >=1.23,<3
+        # we need to enforce the solver to choose a libarrow that has
+        # https://github.com/conda-forge/arrow-cpp-feedstock/pull/1919
+        # since prior builds had no azure constraints, it needs to be
+        # attached to another package; can be dropped for pyarrow v24
+        - libprotobuf >=6.33.5  # [win]
+
+    test:
+      requires:
+        - cuda-driver-dev   # [cuda_compiler_version != "None" and linux]
+      imports:
+        - pyarrow
+        # Compute can be imported but the underlying libarrow_acero is not present.
+        - pyarrow.compute
+        - pyarrow.csv
+        - pyarrow.json
+        - pyarrow.fs
+        - pyarrow.orc
+        - pyarrow._azurefs
+        - pyarrow._gcsfs
+        - pyarrow._hdfs
+        - pyarrow._s3fs
+      commands:
+        # libraries that depend on python (and hence aren't in libarrow itself)
+        - test -f ${SP_DIR}/pyarrow/libarrow_python.so                              # [linux]
+        - test -f ${SP_DIR}/pyarrow/libarrow_python_flight.so                       # [linux]
+        - test -f ${SP_DIR}/pyarrow/libarrow_python_parquet_encryption.so           # [linux]
+        - test -f ${SP_DIR}/pyarrow/libarrow_python.dylib                           # [osx]
+        - test -f ${SP_DIR}/pyarrow/libarrow_python_flight.dylib                    # [osx]
+        - test -f ${SP_DIR}/pyarrow/libarrow_python_parquet_encryption.dylib        # [osx]
+        - if not exist %SP_DIR%\pyarrow\arrow_python.dll exit 1                     # [win]
+        - if not exist %SP_DIR%\pyarrow\arrow_python_flight.dll exit 1              # [win]
+        - if not exist %SP_DIR%\pyarrow\arrow_python_parquet_encryption.dll exit 1  # [win]
+
+        - test -f ${SP_DIR}/pyarrow/include/arrow/python/pyarrow.h                  # [unix]
+        - if not exist %SP_DIR%\pyarrow\include\arrow\python\pyarrow.h exit 1       # [win]
+
+        - test ! -f ${SP_DIR}/pyarrow/tests/test_array.py                           # [unix]
+        - if exist %SP_DIR%/pyarrow/tests/test_array.py exit 1                      # [win]
+        # Need to remove dot from PY_VER; %MYVAR:x=y% replaces "x" in %MYVAR% with "y"
+        - if not exist %SP_DIR%/pyarrow/_cuda.cp%PY_VER:.=%-win_amd64.pyd exit 1    # [win and cuda_compiler_version != "None" and not is_freethreading]
+
+        # Expected not included libraries
+        - test ! -f $PREFIX/lib/libarrow_acero${SHLIB_EXT}      # [unix]
+        - test ! -f $PREFIX/lib/libarrow_dataset${SHLIB_EXT}    # [unix]
+        - test ! -f $PREFIX/lib/libarrow_flight${SHLIB_EXT}     # [unix]
+        - test ! -f $PREFIX/lib/libgandiva${SHLIB_EXT}          # [unix]
+        - test ! -f $PREFIX/lib/libparquet${SHLIB_EXT}          # [unix]
+
+        # we cannot do imports for CUDA builds directly because the library
+        # tries loading the driver library that conda-forge cannot ship;
+        # we trick the package with LD_PRELOAD to pass the import tests
+        - export LD_PRELOAD="$PREFIX/lib/stubs/libcuda.so"      # [cuda_compiler_version != "None" and linux]
+        - python -c "import pyarrow.cuda"                       # [cuda_compiler_version != "None" and linux]
+
+    about:
+      home: http://github.com/apache/arrow
+      license: Apache-2.0
+      license_file:
+        - LICENSE.txt
+      summary: Python libraries for Apache Arrow Core
+
+  - name: pyarrow
+    version: {{ version }}
+    requirements:
+      host:
+        # only necessary for run-exports
+        - python
+      run:
+        # do not use pin_compatible because pyarrow-core has CUDA/non-CUDA variants
+        - pyarrow-core {{ version }} *_{{ PKG_BUILDNUM }}_*
+        # Default doesn't contain flight, flight-sql and gandiva
+        - libarrow-acero {{ version }}.*
+        - libarrow-dataset {{ version }}.*
+        - libarrow-substrait {{ version }}.*
+        - libparquet {{ version }}.*
+        - python
+
+    test:
+      files:
+        - test_read_parquet.py
+      imports:
+        # default pyarrow contains parquet
+        - pyarrow.dataset
+        - pyarrow.parquet
+      commands:
+        # Expected not included libraries
+        - test ! -f $PREFIX/lib/libarrow_flight${SHLIB_EXT}                        # [unix]
+        - test ! -f $PREFIX/lib/libgandiva${SHLIB_EXT}                             # [unix]
+
+        - python test_read_parquet.py
+
+    about:
+      home: http://github.com/apache/arrow
+      license: Apache-2.0
+      license_file:
+        - LICENSE.txt
+      summary: Python libraries for Apache Arrow with default capabilities
+
+  - name: pyarrow-all
+    version: {{ version }}
+    requirements:
+      host:
+        # only necessary for run-exports
+        - python
+      run:
+        - pyarrow {{ version }} *_{{ PKG_BUILDNUM }}
+        - libarrow-flight {{ version }}.*
+        - libarrow-flight-sql {{ version }}.*
+        - libarrow-gandiva {{ version }}.*
+        - libarrow-substrait {{ version }}.*
+        - python
+
+    test:
+      imports:
+        - pyarrow.flight
+        - pyarrow.gandiva
+        - pyarrow.substrait
+    about:
+      home: http://github.com/apache/arrow
+      license: Apache-2.0
+      license_file:
+        - LICENSE.txt
+      summary: Python libraries for Apache Arrow with all capabilities
+
+  - name: pyarrow-tests
+    script: build-pyarrow.sh   # [unix]
+    script: build-pyarrow.bat  # [win]
+    version: {{ version }}
+    build:
+      skip: true               # [cuda_compiler_version != "None"]
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ stdlib("c") }}
+        - {{ compiler("cxx") }}
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - cython                                 # [build_platform != target_platform]
+        - numpy                                  # [build_platform != target_platform]
+        - cmake
+        - ninja
+      host:
+        - pyarrow-all {{ version }} *_{{ PKG_BUILDNUM }}
+        - libarrow-all {{ version }}.*
+        # only for helping resolver
+        - libarrow {{ version }}.* *{{ build_ext }}
+        - clangdev {{ llvm_version }}
+        - llvmdev {{ llvm_version }}
+        - zlib
+        - cython
+        - numpy
+        - python
+        - pip
+        - scikit-build-core
+        - setuptools-scm
+      run:
+        - pyarrow-all {{ version }} *_{{ PKG_BUILDNUM }}
+        - python
+
+    test:
+      requires:
+        # test_cpp_extension_in_python requires a compiler
+        - {{ compiler("cxx") }}  # [linux]
+        - pytest
+        - boto3         # [not is_freethreading]
+        - cffi
+        - cloudpickle
+        - cython
+        - fastparquet   # [not is_freethreading]
+        - fsspec
+        - hypothesis
+        - minio-server
+        - pandas
+        - pytz
+        - s3fs >=2023   # [not is_freethreading]
+        - scipy
+        - sparse        # [not is_freethreading]
+        # these are generally (far) behind on migrating abseil/grpc/protobuf,
+        # and using them as test dependencies blocks the migrator unnecessarily
+        # - pytorch
+        # - tensorflow
+        # we're not building java bindings
+        # - jpype1
+        # doesn't get picked up correctly
+        # - libhdfs3
+      source_files:
+        - cpp/submodules/parquet-testing/data
+        - testing/data
+      commands:
+        - cd ${SP_DIR}                                      # [unix]
+        - cd %SP_DIR%                                       # [win]
+        - export ARROW_TEST_DATA="${SRC_DIR}/testing/data"  # [unix]
+        - set "ARROW_TEST_DATA=%SRC_DIR%\testing\data"      # [win]
+        - export PARQUET_TEST_DATA="${SRC_DIR}/cpp/submodules/parquet-testing/data"  # [unix]
+        - set "PARQUET_TEST_DATA=%SRC_DIR%\cpp\submodules\parquet-testing\data"      # [win]
+
+        {% set tests_to_skip = "_not_a_real_test" %}
+        # we do not have GPUs in CI --> cannot test cuda
+        {% set tests_to_skip = tests_to_skip + " or test_cuda" + " or test_dlpack_cuda_not_supported"%}
+        # skip tests that raise SIGINT and crash the test suite
+        {% set tests_to_skip = tests_to_skip + " or (test_csv and test_cancellation)" %}  # [linux]
+        {% set tests_to_skip = tests_to_skip + " or (test_flight and test_interrupt)" %}  # [linux]
+        # skip tests that make invalid(-for-conda) assumptions about the compilers setup
+        {% set tests_to_skip = tests_to_skip + " or test_cython_api" %}                   # [unix]
+        {% set tests_to_skip = tests_to_skip + " or test_visit_strings" %}                # [unix]
+        # skip tests that cannot succeed in emulation
+        {% set tests_to_skip = tests_to_skip + " or test_debug_memory_pool_disabled" %}   # [aarch64 or ppc64le]
+        {% set tests_to_skip = tests_to_skip + " or test_env_var_io_thread_count" %}      # [aarch64 or ppc64le]
+        # vvvvvvv TESTS THAT SHOULDN'T HAVE TO BE SKIPPED vvvvvvv
+        # flaky test based on s3 connection
+        {% set tests_to_skip = tests_to_skip + " or test_s3_real_aws_region_selection" %}
+        # https://github.com/apache/arrow/issues/45229
+        {% set tests_to_skip = tests_to_skip + " or test_sparse_coo_tensor_scipy_roundtrip" %}
+        # this test is trying to simulate a failure mode using /usr/share/zoneinfo,
+        # but newer orc will ignore that if it finds a tzinfo in a conda environment
+        {% set tests_to_skip = tests_to_skip + " or test_timezone_absent" %}
+        # https://github.com/apache/arrow/issues/43800
+        {% set tests_to_skip = tests_to_skip + " or test_cpp_extension_in_python" %}                # [osx]
+        # https://github.com/apache/arrow/issues/43356
+        {% set tests_to_skip = tests_to_skip + " or (test_compute and test_assume_timezone)" %}     # [aarch64 or ppc64le]
+        {% set tests_to_skip = tests_to_skip + " or (test_compute and test_strftime)" %}            # [aarch64 or ppc64le]
+        {% set tests_to_skip = tests_to_skip + " or (test_compute and test_round_temporal)" %}      # [aarch64 or ppc64le]
+        {% set tests_to_skip = tests_to_skip + " or test_extract_datetime_components " %}           # [aarch64 or ppc64le]
+        # flaky test that fails regularly on aarch
+        {% set tests_to_skip = tests_to_skip + " or test_feather_format[serial]" %}                 # [aarch64 or ppc64le]
+        # gandiva tests are segfaulting on ppc
+        {% set tests_to_skip = tests_to_skip + " or test_gandiva" %}                                # [ppc64le]
+        # fastparquet is not compatible with pandas 3
+        # https://github.com/apache/arrow/issues/49839
+        {% set tests_to_skip = tests_to_skip + " or test_fastparquet_cross_compatibility" %}
+        # ^^^^^^^ TESTS THAT SHOULDN'T HAVE TO BE SKIPPED ^^^^^^^
+        - pytest pyarrow/ -rfEs -k "not ({{ tests_to_skip }})"
+
+    about:
+      home: http://github.com/apache/arrow
+      license: Apache-2.0
+      license_file:
+        - LICENSE.txt
+      summary: Python test files for Apache Arrow
+
 about:
   home: http://github.com/apache/arrow
   license: Apache-2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "24.0.0" %}
+{% set version = "25.0.0.rc1" %}
 {% set cuda_enabled = cuda_compiler_version != "None" %}
 {% set build_ext_version = "5.0.0" %}
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}
@@ -16,9 +16,10 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://www.apache.org/dyn/closer.lua/arrow/arrow-{{ version }}/apache-arrow-{{ version }}.tar.gz?action=download
-    fn: apache-arrow-{{ version }}.tar.gz
-    sha256: 9a8094d24fa33b90c672ab77fdda253f29300c8b0dd3f0b8e55a29dbd98b82c9
+  # - url: https://www.apache.org/dyn/closer.lua/arrow/arrow-{{ version }}/apache-arrow-{{ version }}.tar.gz?action=download
+  #   fn: apache-arrow-{{ version }}.tar.gz
+  - url: https://github.com/apache/arrow/releases/download/apache-arrow-{{ version.replace(".rc", "-rc") }}/apache-arrow-{{ ".".join(version.split(".")[:3]) }}.tar.gz
+    sha256: 12afc2dc8137bdd4a68876cec939f664c9d55cfc7b75f55b45163ebb4e344d81
     patches:
       # skip gcsfs tests due to missing `storage-testbench`
       - patches/0001-disable-gcsfs_test.patch
@@ -30,14 +31,14 @@ source:
 
   # testing-submodules not part of release tarball
   - git_url: https://github.com/apache/arrow-testing.git
-    git_rev: 249079a810caedda6898464003c7ef8a47efeeae
+    git_rev: 9ff285c88565f0f6abc855918c6a342e70e4909c
     folder: testing
   - git_url: https://github.com/apache/parquet-testing.git
     git_rev: e74785d85a4ecee829e1e405444d6a1b24b8bc9c
     folder: cpp/submodules/parquet-testing
 
 build:
-  number: 9
+  number: 0
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1027,6 +1027,7 @@ outputs:
         - pyarrow-all {{ version }} *_{{ PKG_BUILDNUM }}
         - python
 
+    {% if (build_platform == target_platform) or py == 311 %}
     test:
       requires:
         # test_cpp_extension_in_python requires a compiler
@@ -1100,6 +1101,7 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or test_fastparquet_cross_compatibility" %}
         # ^^^^^^^ TESTS THAT SHOULDN'T HAVE TO BE SKIPPED ^^^^^^^
         - pytest pyarrow/ -rfEs -k "not ({{ tests_to_skip }})"
+    {% endif %}
 
     about:
       home: http://github.com/apache/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -807,7 +807,6 @@ outputs:
       string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}
       ignore_run_exports_from:
         - {{ compiler("cuda") }}                 # [cuda_compiler_version != "None"]
-        - libarrow-all
         # we don't need numpy at runtime, just to build
         - numpy
       rpaths:
@@ -847,7 +846,7 @@ outputs:
       host:
         # We add all libarrow package dependencies on host in order
         # to build pyarrow once with all capabilities.
-        - libarrow-all {{ version }}.* *{{ build_ext }}
+        - {{ pin_subpackage("libarrow-all", exact=True) }}
         - clangdev {{ llvm_version }}
         - llvmdev {{ llvm_version }}
         - zlib
@@ -862,9 +861,9 @@ outputs:
         # We ignore the run-exports from libarrow-all and restrict to only
         # libarrow, as we don't want the other libraries to be installed when
         # running for pyarrow-core, where the aim is a low storage footprint.
-        - libarrow {{ version }}.* *{{ build_ext }}
+        - {{ pin_subpackage("libarrow", exact=True) }}
         # compute is necessary even for a basic `import pyarrow`
-        - libarrow-compute {{ version }}.* *{{ build_ext }}
+        - {{ pin_subpackage("libarrow-compute", exact=True) }}
         - python
       run_constrained:
         - apache-arrow-proc * {{ build_ext }}
@@ -939,13 +938,13 @@ outputs:
         # only necessary for run-exports
         - python
       run:
+        # Default doesn't contain flight, flight-sql and gandiva
+        - {{ pin_subpackage("libarrow-acero", exact=True) }}
+        - {{ pin_subpackage("libarrow-dataset", exact=True) }}
+        - {{ pin_subpackage("libarrow-substrait", exact=True) }}
+        - {{ pin_subpackage("libparquet", exact=True) }}
         # do not use pin_compatible because pyarrow-core has CUDA/non-CUDA variants
         - pyarrow-core {{ version }} *_{{ PKG_BUILDNUM }}_*
-        # Default doesn't contain flight, flight-sql and gandiva
-        - libarrow-acero {{ version }}.*
-        - libarrow-dataset {{ version }}.*
-        - libarrow-substrait {{ version }}.*
-        - libparquet {{ version }}.*
         - python
 
     test:
@@ -976,11 +975,11 @@ outputs:
         # only necessary for run-exports
         - python
       run:
+        - {{ pin_subpackage("libarrow-flight", exact=True) }}
+        - {{ pin_subpackage("libarrow-flight-sql", exact=True) }}
+        - {{ pin_subpackage("libarrow-gandiva", exact=True) }}
+        - {{ pin_subpackage("libarrow-substrait", exact=True) }}
         - pyarrow {{ version }} *_{{ PKG_BUILDNUM }}
-        - libarrow-flight {{ version }}.*
-        - libarrow-flight-sql {{ version }}.*
-        - libarrow-gandiva {{ version }}.*
-        - libarrow-substrait {{ version }}.*
         - python
 
     test:
@@ -1013,10 +1012,8 @@ outputs:
         - cmake
         - ninja
       host:
+        - {{ pin_subpackage("libarrow-all", exact=True) }}
         - pyarrow-all {{ version }} *_{{ PKG_BUILDNUM }}
-        - libarrow-all {{ version }}.*
-        # only for helping resolver
-        - libarrow {{ version }}.* *{{ build_ext }}
         - clangdev {{ llvm_version }}
         - llvmdev {{ llvm_version }}
         - zlib

--- a/recipe/test_read_parquet.py
+++ b/recipe/test_read_parquet.py
@@ -1,0 +1,5 @@
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+table = pa.Table.from_pydict({"a": [1, 2]})
+pq.write_table(table, "test.parquet")


### PR DESCRIPTION
Some changes require testing across both libarrow and pyarrow; since we split off the pyarrow builds in a66c7c666f1ca3ee1f4ffcf825e9f61d2d6bd77b, we'd need to publish a changed `libarrow`, test the changes in pyarrow, and then potentially mark the builds as broken. In order to simplify this process, reintroduce some end-to-end testing here that can be used to do this all in one PR.

Continued from #1432