### PR TITLE
add a fallback to null in CONDA_BUILD check

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -22,7 +22,7 @@ _la_log() {
 # (CONDA_BUILD is also set in the test stage, and we don't want to skip there.)
 # Otherwise, the symlinks will be included in packages built with libarrow as a host dependency.
 # see https://github.com/conda-forge/arrow-cpp-feedstock/issues/1478
-if [ -n "$CONDA_BUILD" ] && [ "${CONDA_BUILD_STATE:-0}" != "TEST" ]; then
+if [ -n "${CONDA_BUILD:-}" ] && [ "${CONDA_BUILD_STATE:-0}" != "TEST" ]; then
     _la_log "CONDA_BUILD is set to $CONDA_BUILD (and CONDA_BUILD_STATE != \"TEST\"), skipping libarrow activation."
     return 0
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     folder: cpp/submodules/parquet-testing
 
 build:
-  number: 7
+  number: 8
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.
   skip: true  # [cuda_compiler_version not in ("None", cuda_compiler_version_min)]


### PR DESCRIPTION
## Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Fixes #1695

Follow-up to #1694

This proposes changing the condition `if [ -n "${CONDA_BUILD}" ]` to `if [ -n "${CONDA_BUILD:-}" ]` (adding a fallback to null), so that activating an environment with `libarrow` in it in a bash process with `-e -u` set does not fail.

I *think* this state still achieves the design goals of #1694.

Thanks for your time and consideration.