### PR TITLE
[main] Stay on CUDA 11.8

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -77,8 +77,8 @@ thrift_cpp:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
+  - cuda_compiler
   - docker_image
 zlib:
 - '1'

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -27,7 +27,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -77,8 +77,8 @@ thrift_cpp:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
+  - cuda_compiler
   - docker_image
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -77,8 +77,8 @@ thrift_cpp:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
+  - cuda_compiler
   - docker_image
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -27,7 +27,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -77,8 +77,8 @@ thrift_cpp:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
+  - cuda_compiler
   - docker_image
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -77,8 +77,8 @@ thrift_cpp:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
+  - cuda_compiler
   - docker_image
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -27,7 +27,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -77,8 +77,8 @@ thrift_cpp:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
+  - cuda_compiler
   - docker_image
 zlib:
 - '1'

--- a/.ci_support/migrations/cuda118.yaml
+++ b/.ci_support/migrations/cuda118.yaml
@@ -1,0 +1,70 @@
+migrator_ts: 1748496951
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+  # This is intended as a _manual_ migrator to re-add CUDA 11.8, after we
+  # dropped it as version that's built by default; DO NOT unpause
+  paused: true
+  override_cbc_keys:
+    - cuda_compiler_stub
+  operation: key_add
+  check_solvable: false
+  primary_key: cuda_compiler_version
+  additional_zip_keys:
+    - cuda_compiler
+    - docker_image         # [linux]
+  ordering:
+    cuda_compiler:
+      - None
+      - cuda-nvcc
+      - nvcc
+    cuda_compiler_version:
+      - 12.4
+      - 12.6
+      - 12.8
+      - None
+      - 12.9
+      - 11.8
+    cuda_compiler_version_min:
+      - 12.4
+      - 12.6
+      - 12.8
+      - 12.9
+      - 11.8
+
+cuda_compiler:              # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - nvcc                    # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cuda_compiler_version:      # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.8                    # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cuda_compiler_version_min:  # [linux or win64]
+  - 11.8                    # [linux or win64]
+
+c_compiler_version:         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cxx_compiler_version:       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+fortran_compiler_version:   # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+docker_image:                                             # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  ### Docker images with CUDA 11.8 support
+
+  # CUDA 11.8 builds (only x64 has a DEFAULT_LINUX_VERSION choice; alma9 not available)
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:cos7   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "ubi8") == "cos7"]
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "ubi8") in ("ubi8", "alma8", "alma9")]
+
+  # CUDA 11.8 arch: native compilation (build == target)
+  - quay.io/condaforge/linux-anvil-aarch64-cuda11.8:ubi8  # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+  - quay.io/condaforge/linux-anvil-ppc64le-cuda11.8:ubi8  # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+
+  # CUDA 11.8 arch: cross-compilation (build != target)
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8   # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8   # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/.ci_support/win_64_cuda_compiler_version11.8.yaml
+++ b/.ci_support/win_64_cuda_compiler_version11.8.yaml
@@ -59,8 +59,8 @@ target_platform:
 thrift_cpp:
 - 0.21.0
 zip_keys:
-- - cuda_compiler
-  - cuda_compiler_version
+- - cuda_compiler_version
+  - cuda_compiler
 zlib:
 - '1'
 zstd:

--- a/.ci_support/win_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNone.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
 - None
 cuda_compiler_version_min:
@@ -59,8 +59,8 @@ target_platform:
 thrift_cpp:
 - 0.21.0
 zip_keys:
-- - cuda_compiler
-  - cuda_compiler_version
+- - cuda_compiler_version
+  - cuda_compiler
 zlib:
 - '1'
 zstd:

--- a/build-locally.py
+++ b/build-locally.py
@@ -106,9 +106,7 @@ def main(args=None):
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -124,9 +122,7 @@ def main(args=None):
         elif ns.config.startswith("win"):
             run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ source:
     folder: cpp/submodules/parquet-testing
 
 build:
-  number: 6
+  number: 7
 
   # for cuda support, building with one version is enough to be compatible with
   # all later versions, since arrow is only using libcuda, and not libcudart.


### PR DESCRIPTION
With the removal of CUDA 11.8 as a default version, our `cuda_compiler_version_min` will soon be 12.6 or even 12.9

Given that we have a custom migrator for the [express purpose](https://conda-forge.org/news/2025/05/29/cuda-118/) of staying on CUDA 11.8 where that's necessary or beneficial, and given that @kkraus14 has always advocated for keeping the lowest-possible bound in `__cuda >=X`, let's use this here.

~This currently uses fix-ups from https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7482 & https://github.com/conda-forge/conda-smithy/pull/2338 to work. Once those things have settled, I'm happy to backport this to the maintenance branches.~